### PR TITLE
[#27] Built-in renderables: Text

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -68,6 +68,26 @@ export { Renderable, resetNodeIdCounter } from "./renderable.js";
 // RenderableTree
 export { RenderableTree } from "./renderable-tree.js";
 
+// TextRenderable
+export {
+  TextRenderable,
+  alignLine,
+  measureText,
+  resolveSpans,
+  truncateLine,
+  wrapText,
+} from "./text.js";
+export type {
+  AlignLineOptions,
+  StyledChar,
+  TextAlign,
+  TextMeasurement,
+  TextOptions,
+  TextOverflow,
+  TextSpan,
+  TextWrap,
+} from "./text.js";
+
 /**
  * Calls the native Rust `hello()` function and returns its string result.
  *

--- a/packages/core/src/text.test.ts
+++ b/packages/core/src/text.test.ts
@@ -1,0 +1,451 @@
+import { describe, expect, it, beforeEach } from "bun:test";
+import { resetNodeIdCounter } from "./renderable.js";
+import {
+  TextRenderable,
+  resolveSpans,
+  wrapText,
+  truncateLine,
+  alignLine,
+  measureText,
+  type StyledChar,
+  type TextSpan,
+} from "./text.js";
+import type { TextStyle } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Extract plain text from an array of StyledChar. */
+const toText = (chars: StyledChar[]): string => chars.map((c) => c.ch).join("");
+
+/** Create unstyled StyledChars from a string. */
+const plain = (str: string): StyledChar[] =>
+  Array.from(str, (ch) => ({ ch, style: {} }));
+
+// ---------------------------------------------------------------------------
+// resolveSpans
+// ---------------------------------------------------------------------------
+
+describe("resolveSpans", () => {
+  it("applies base style to all characters", () => {
+    const base: TextStyle = { bold: true };
+    const result = resolveSpans("abc", base, []);
+    expect(result).toHaveLength(3);
+    expect(result[0].style.bold).toBe(true);
+    expect(result[1].style.bold).toBe(true);
+    expect(result[2].style.bold).toBe(true);
+  });
+
+  it("applies a span overlay", () => {
+    const base: TextStyle = {};
+    const spans: TextSpan[] = [{ start: 1, end: 3, style: { italic: true } }];
+    const result = resolveSpans("abcd", base, spans);
+    expect(result[0].style.italic).toBeUndefined();
+    expect(result[1].style.italic).toBe(true);
+    expect(result[2].style.italic).toBe(true);
+    expect(result[3].style.italic).toBeUndefined();
+  });
+
+  it("later spans override earlier spans", () => {
+    const base: TextStyle = {};
+    const red: TextStyle = { fg: { type: "rgb", r: 255, g: 0, b: 0 } };
+    const blue: TextStyle = { fg: { type: "rgb", r: 0, g: 0, b: 255 } };
+    const spans: TextSpan[] = [
+      { start: 0, end: 4, style: red },
+      { start: 2, end: 4, style: blue },
+    ];
+    const result = resolveSpans("abcd", base, spans);
+    expect(result[0].style.fg).toEqual(red.fg);
+    expect(result[1].style.fg).toEqual(red.fg);
+    expect(result[2].style.fg).toEqual(blue.fg);
+    expect(result[3].style.fg).toEqual(blue.fg);
+  });
+
+  it("clamps span indices to text bounds", () => {
+    const result = resolveSpans("ab", {}, [
+      { start: -5, end: 100, style: { bold: true } },
+    ]);
+    expect(result).toHaveLength(2);
+    expect(result[0].style.bold).toBe(true);
+    expect(result[1].style.bold).toBe(true);
+  });
+
+  it("returns empty array for empty text", () => {
+    const result = resolveSpans("", {}, []);
+    expect(result).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// wrapText
+// ---------------------------------------------------------------------------
+
+describe("wrapText", () => {
+  it("no-wrap keeps text on one line per hard newline", () => {
+    const chars = plain("hello world");
+    const lines = wrapText(chars, "no-wrap", 5);
+    expect(lines).toHaveLength(1);
+    expect(toText(lines[0])).toBe("hello world");
+  });
+
+  it("no-wrap splits on hard newlines", () => {
+    const chars = plain("line1\nline2");
+    const lines = wrapText(chars, "no-wrap", 5);
+    expect(lines).toHaveLength(2);
+    expect(toText(lines[0])).toBe("line1");
+    expect(toText(lines[1])).toBe("line2");
+  });
+
+  it("break-word breaks at exact character boundaries", () => {
+    const chars = plain("abcdefgh");
+    const lines = wrapText(chars, "break-word", 3);
+    expect(lines).toHaveLength(3);
+    expect(toText(lines[0])).toBe("abc");
+    expect(toText(lines[1])).toBe("def");
+    expect(toText(lines[2])).toBe("gh");
+  });
+
+  it("word-wrap breaks at word boundaries", () => {
+    const chars = plain("hello world foo");
+    const lines = wrapText(chars, "word-wrap", 11);
+    expect(lines).toHaveLength(2);
+    expect(toText(lines[0])).toBe("hello world");
+    expect(toText(lines[1])).toBe("foo");
+  });
+
+  it("word-wrap breaks long words", () => {
+    const chars = plain("abcdefghij");
+    const lines = wrapText(chars, "word-wrap", 4);
+    expect(lines.length).toBeGreaterThanOrEqual(2);
+    // First chunks should be 4 chars
+    expect(toText(lines[0])).toBe("abcd");
+    expect(toText(lines[1])).toBe("efgh");
+    expect(toText(lines[2])).toBe("ij");
+  });
+
+  it("handles empty text", () => {
+    const lines = wrapText([], "word-wrap", 10);
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toHaveLength(0);
+  });
+
+  it("handles text with no maxWidth", () => {
+    const chars = plain("hello world");
+    const lines = wrapText(chars, "word-wrap", undefined);
+    expect(lines).toHaveLength(1);
+    expect(toText(lines[0])).toBe("hello world");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// truncateLine
+// ---------------------------------------------------------------------------
+
+describe("truncateLine", () => {
+  it("returns line unchanged if within width", () => {
+    const line = plain("abc");
+    const result = truncateLine(line, 5, "clip");
+    expect(toText(result)).toBe("abc");
+  });
+
+  it("clips to maxWidth", () => {
+    const line = plain("abcdef");
+    const result = truncateLine(line, 3, "clip");
+    expect(toText(result)).toBe("abc");
+  });
+
+  it("truncates with ellipsis", () => {
+    const line = plain("abcdef");
+    const result = truncateLine(line, 3, "ellipsis");
+    expect(result).toHaveLength(3);
+    expect(result[2].ch).toBe("\u2026");
+    expect(toText(result)).toBe("ab\u2026");
+  });
+
+  it("handles maxWidth of 1 with ellipsis", () => {
+    const line = plain("abc");
+    const result = truncateLine(line, 1, "ellipsis");
+    expect(result).toHaveLength(1);
+    expect(result[0].ch).toBe("\u2026");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// alignLine
+// ---------------------------------------------------------------------------
+
+describe("alignLine", () => {
+  const fillStyle: TextStyle = {};
+
+  it("left alignment returns line as-is", () => {
+    const line = plain("hi");
+    const result = alignLine({ line, width: 5, align: "left", fillStyle });
+    expect(toText(result)).toBe("hi");
+  });
+
+  it("right alignment pads on the left", () => {
+    const line = plain("hi");
+    const result = alignLine({ line, width: 5, align: "right", fillStyle });
+    expect(toText(result)).toBe("   hi");
+    expect(result).toHaveLength(5);
+  });
+
+  it("center alignment pads on both sides", () => {
+    const line = plain("hi");
+    const result = alignLine({ line, width: 6, align: "center", fillStyle });
+    expect(result).toHaveLength(6);
+    expect(toText(result)).toBe("  hi  ");
+  });
+
+  it("center alignment with odd gap favors left", () => {
+    const line = plain("hi");
+    const result = alignLine({ line, width: 5, align: "center", fillStyle });
+    expect(result).toHaveLength(5);
+    expect(toText(result)).toBe(" hi  ");
+  });
+
+  it("does not pad if line is already wider", () => {
+    const line = plain("hello");
+    const result = alignLine({ line, width: 3, align: "center", fillStyle });
+    expect(toText(result)).toBe("hello");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// measureText
+// ---------------------------------------------------------------------------
+
+describe("measureText", () => {
+  it("measures simple text", () => {
+    const m = measureText("hello", "no-wrap");
+    expect(m.width).toBe(5);
+    expect(m.height).toBe(1);
+  });
+
+  it("measures multi-line text", () => {
+    const m = measureText("hello\nworld!", "no-wrap");
+    expect(m.width).toBe(6); // "world!" is 6 chars
+    expect(m.height).toBe(2);
+  });
+
+  it("measures with wrapping constraint", () => {
+    const m = measureText("hello world", "word-wrap", 6);
+    expect(m.height).toBe(2);
+    expect(m.width).toBeLessThanOrEqual(6);
+  });
+
+  it("measures empty text", () => {
+    const m = measureText("", "no-wrap");
+    expect(m.width).toBe(0);
+    expect(m.height).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// TextRenderable
+// ---------------------------------------------------------------------------
+
+describe("TextRenderable", () => {
+  beforeEach(() => {
+    resetNodeIdCounter();
+  });
+
+  it("constructs with defaults", () => {
+    const t = new TextRenderable();
+    expect(t.wrap).toBe("word-wrap");
+    expect(t.overflow).toBe("clip");
+    expect(t.align).toBe("left");
+    expect(t.spans).toHaveLength(0);
+    expect(t.text).toBeUndefined();
+  });
+
+  it("constructs with options", () => {
+    const t = new TextRenderable({
+      text: "hello",
+      wrap: "no-wrap",
+      overflow: "ellipsis",
+      align: "center",
+      spans: [{ start: 0, end: 2, style: { bold: true } }],
+    });
+    expect(t.text).toBe("hello");
+    expect(t.wrap).toBe("no-wrap");
+    expect(t.overflow).toBe("ellipsis");
+    expect(t.align).toBe("center");
+    expect(t.spans).toHaveLength(1);
+  });
+
+  it("assigns a node ID", () => {
+    const t = new TextRenderable();
+    expect(t.nodeId).toBe(1);
+  });
+
+  it("setWrap marks dirty", () => {
+    const t = new TextRenderable();
+    t.clearDirty();
+    t.setWrap("break-word");
+    expect(t.dirty).toBe(true);
+    expect(t.wrap).toBe("break-word");
+  });
+
+  it("setWrap does not mark dirty if same value", () => {
+    const t = new TextRenderable({ wrap: "no-wrap" });
+    t.clearDirty();
+    t.setWrap("no-wrap");
+    expect(t.dirty).toBe(false);
+  });
+
+  it("setOverflow marks dirty", () => {
+    const t = new TextRenderable();
+    t.clearDirty();
+    t.setOverflow("ellipsis");
+    expect(t.dirty).toBe(true);
+  });
+
+  it("setAlign marks dirty", () => {
+    const t = new TextRenderable();
+    t.clearDirty();
+    t.setAlign("center");
+    expect(t.dirty).toBe(true);
+  });
+
+  it("setSpans marks dirty", () => {
+    const t = new TextRenderable();
+    t.clearDirty();
+    t.setSpans([{ start: 0, end: 1, style: { bold: true } }]);
+    expect(t.dirty).toBe(true);
+  });
+
+  it("addSpan marks dirty", () => {
+    const t = new TextRenderable();
+    t.clearDirty();
+    t.addSpan({ start: 0, end: 1, style: { italic: true } });
+    expect(t.dirty).toBe(true);
+    expect(t.spans).toHaveLength(1);
+  });
+
+  it("clearSpans marks dirty only if non-empty", () => {
+    const t = new TextRenderable();
+    t.clearDirty();
+    t.clearSpans();
+    expect(t.dirty).toBe(false);
+
+    t.addSpan({ start: 0, end: 1, style: {} });
+    t.clearDirty();
+    t.clearSpans();
+    expect(t.dirty).toBe(true);
+    expect(t.spans).toHaveLength(0);
+  });
+
+  // -----------------------------------------------------------------------
+  // Measurement
+  // -----------------------------------------------------------------------
+
+  it("measure returns intrinsic size", () => {
+    const t = new TextRenderable({ text: "hello" });
+    const m = t.measure();
+    expect(m.width).toBe(5);
+    expect(m.height).toBe(1);
+  });
+
+  it("measure with maxWidth wraps text", () => {
+    const t = new TextRenderable({ text: "hello world" });
+    const m = t.measure(6);
+    expect(m.height).toBe(2);
+  });
+
+  it("measure with empty text", () => {
+    const t = new TextRenderable();
+    const m = t.measure();
+    expect(m.width).toBe(0);
+    expect(m.height).toBe(0);
+  });
+
+  // -----------------------------------------------------------------------
+  // Rendering
+  // -----------------------------------------------------------------------
+
+  it("render produces styled lines", () => {
+    const t = new TextRenderable({ text: "hello" });
+    const lines = t.render(10);
+    expect(lines).toHaveLength(1);
+    expect(toText(lines[0])).toBe("hello");
+  });
+
+  it("render wraps text", () => {
+    const t = new TextRenderable({ text: "hello world", wrap: "word-wrap" });
+    const lines = t.render(6);
+    expect(lines).toHaveLength(2);
+    expect(toText(lines[0]).trimEnd()).toBe("hello");
+  });
+
+  it("render truncates with ellipsis", () => {
+    const t = new TextRenderable({
+      text: "hello world",
+      wrap: "no-wrap",
+      overflow: "ellipsis",
+    });
+    const lines = t.render(5);
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toHaveLength(5);
+    expect(lines[0][4].ch).toBe("\u2026");
+  });
+
+  it("render aligns center", () => {
+    const t = new TextRenderable({
+      text: "hi",
+      align: "center",
+    });
+    const lines = t.render(6);
+    expect(lines).toHaveLength(1);
+    expect(toText(lines[0])).toBe("  hi  ");
+  });
+
+  it("render aligns right", () => {
+    const t = new TextRenderable({
+      text: "hi",
+      align: "right",
+    });
+    const lines = t.render(5);
+    expect(lines).toHaveLength(1);
+    expect(toText(lines[0])).toBe("   hi");
+  });
+
+  it("render applies inline spans", () => {
+    const t = new TextRenderable({
+      text: "abcd",
+      spans: [{ start: 1, end: 3, style: { bold: true } }],
+    });
+    const lines = t.render();
+    expect(lines).toHaveLength(1);
+    expect(lines[0][0].style.bold).toBeUndefined();
+    expect(lines[0][1].style.bold).toBe(true);
+    expect(lines[0][2].style.bold).toBe(true);
+    expect(lines[0][3].style.bold).toBeUndefined();
+  });
+
+  it("render returns empty for empty text", () => {
+    const t = new TextRenderable();
+    const lines = t.render(10);
+    expect(lines).toHaveLength(0);
+  });
+
+  it("render uses layout width when no maxWidth given", () => {
+    const t = new TextRenderable({ text: "hello world" });
+    t.updateLayout({ x: 0, y: 0, width: 6, height: 2 });
+    const lines = t.render();
+    expect(lines).toHaveLength(2);
+  });
+
+  // -----------------------------------------------------------------------
+  // Style integration
+  // -----------------------------------------------------------------------
+
+  it("inherits text style from setStyle", () => {
+    const t = new TextRenderable({ text: "hi" });
+    t.setStyle({ color: "red", fontWeight: "bold" });
+    const lines = t.render();
+    expect(lines[0][0].style.fg).toEqual({ type: "rgb", r: 255, g: 0, b: 0 });
+    expect(lines[0][0].style.bold).toBe(true);
+  });
+});

--- a/packages/core/src/text.ts
+++ b/packages/core/src/text.ts
@@ -1,0 +1,623 @@
+/**
+ * TextRenderable — styled text display with wrapping, truncation, alignment,
+ * and inline styling spans.
+ *
+ * Extends the Renderable base class and feeds intrinsic size to the layout
+ * engine so Taffy can measure text nodes correctly.
+ */
+
+import type { ComputedLayout, TextStyle } from "./types.js";
+import { Renderable } from "./renderable.js";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const ELLIPSIS = "\u2026";
+const HALF_DIVISOR = 2;
+const ZERO = 0;
+const LAST_OFFSET = 1;
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** How text wraps when it exceeds the available width. */
+export type TextWrap = "word-wrap" | "break-word" | "no-wrap";
+
+/** How text is truncated when it exceeds available space. */
+export type TextOverflow = "clip" | "ellipsis";
+
+/** How text is aligned within its container. */
+export type TextAlign = "left" | "center" | "right";
+
+/**
+ * An inline styling span — applies a TextStyle to a range of text.
+ *
+ * Spans are index-based (UTF-16 code units, matching JS string indexing).
+ * Overlapping spans are applied in order; later spans override earlier ones.
+ */
+export interface TextSpan {
+  /** End index (exclusive). */
+  end: number;
+  /** Start index (inclusive). */
+  start: number;
+  /** Style to apply for this range. */
+  style: TextStyle;
+}
+
+/** Options for constructing a TextRenderable. */
+export interface TextOptions {
+  align?: TextAlign;
+  overflow?: TextOverflow;
+  spans?: TextSpan[];
+  text?: string;
+  wrap?: TextWrap;
+}
+
+// ---------------------------------------------------------------------------
+// Styled character — a character with its resolved style
+// ---------------------------------------------------------------------------
+
+/** A single character with its computed style after span resolution. */
+export interface StyledChar {
+  ch: string;
+  style: TextStyle;
+}
+
+// ---------------------------------------------------------------------------
+// Measurement result
+// ---------------------------------------------------------------------------
+
+/** Intrinsic size of a text block for layout. */
+export interface TextMeasurement {
+  /** Height in rows (number of lines after wrapping). */
+  height: number;
+  /** Width in columns (longest line after wrapping). */
+  width: number;
+}
+
+/** Options for aligning a line of styled characters. */
+export interface AlignLineOptions {
+  align: TextAlign;
+  fillStyle: TextStyle;
+  line: StyledChar[];
+  width: number;
+}
+
+/** Options for flushing a word onto the current line. */
+interface FlushWordOptions {
+  current: StyledChar[];
+  lines: StyledChar[][];
+  width: number;
+  word: StyledChar[];
+}
+
+// ---------------------------------------------------------------------------
+// Helper: merge two TextStyle objects (right overrides left)
+// ---------------------------------------------------------------------------
+
+const applyOverlayColorFg = (result: TextStyle, overlay: TextStyle): void => {
+  if (overlay.fg !== undefined) {
+    result.fg = overlay.fg;
+  }
+  if (overlay.bg !== undefined) {
+    result.bg = overlay.bg;
+  }
+};
+
+const applyOverlayColorDecor = (result: TextStyle, overlay: TextStyle): void => {
+  if (overlay.underlineColor !== undefined) {
+    result.underlineColor = overlay.underlineColor;
+  }
+  if (overlay.underlineStyle !== undefined) {
+    result.underlineStyle = overlay.underlineStyle;
+  }
+};
+
+const applyOverlayFlagsPrimary = (result: TextStyle, overlay: TextStyle): void => {
+  if (overlay.bold !== undefined) {
+    result.bold = overlay.bold;
+  }
+  if (overlay.dim !== undefined) {
+    result.dim = overlay.dim;
+  }
+  if (overlay.italic !== undefined) {
+    result.italic = overlay.italic;
+  }
+  if (overlay.underline !== undefined) {
+    result.underline = overlay.underline;
+  }
+};
+
+const applyOverlayFlagsSecondary = (result: TextStyle, overlay: TextStyle): void => {
+  if (overlay.strikethrough !== undefined) {
+    result.strikethrough = overlay.strikethrough;
+  }
+  if (overlay.overline !== undefined) {
+    result.overline = overlay.overline;
+  }
+  if (overlay.blink !== undefined) {
+    result.blink = overlay.blink;
+  }
+  if (overlay.reverse !== undefined) {
+    result.reverse = overlay.reverse;
+  }
+};
+
+const mergeTextStyle = (base: TextStyle, overlay: TextStyle): TextStyle => {
+  const result: TextStyle = { ...base };
+  applyOverlayColorFg(result, overlay);
+  applyOverlayColorDecor(result, overlay);
+  applyOverlayFlagsPrimary(result, overlay);
+  applyOverlayFlagsSecondary(result, overlay);
+  return result;
+};
+
+// ---------------------------------------------------------------------------
+// Helper: resolve spans to per-character styles
+// ---------------------------------------------------------------------------
+
+/** Build a StyledChar array from text with a base style. */
+const buildStyledChars = (text: string, baseStyle: TextStyle): StyledChar[] =>
+  Array.from(text, (ch) => ({ ch, style: { ...baseStyle } }));
+
+/**
+ * Resolve inline spans to produce a StyledChar array for the entire text.
+ *
+ * The base style is applied to every character, then each span overlays its
+ * style on the matching range. Spans are applied in order.
+ */
+export const resolveSpans = (
+  text: string,
+  baseStyle: TextStyle,
+  spans: TextSpan[],
+): StyledChar[] => {
+  const chars = buildStyledChars(text, baseStyle);
+
+  for (const span of spans) {
+    const start = Math.max(ZERO, span.start);
+    const end = Math.min(text.length, span.end);
+    for (let idx = start; idx < end; idx++) {
+      chars[idx].style = mergeTextStyle(chars[idx].style, span.style);
+    }
+  }
+
+  return chars;
+};
+
+// ---------------------------------------------------------------------------
+// Helper: word-boundary detection
+// ---------------------------------------------------------------------------
+
+const isWhitespace = (ch: string): boolean => ch === " " || ch === "\t";
+
+// ---------------------------------------------------------------------------
+// Wrapping: split on hard newlines
+// ---------------------------------------------------------------------------
+
+const splitOnNewlines = (chars: StyledChar[]): StyledChar[][] => {
+  const segments: StyledChar[][] = [];
+  let seg: StyledChar[] = [];
+  for (const sc of chars) {
+    if (sc.ch === "\n") {
+      segments.push(seg);
+      seg = [];
+    } else {
+      seg.push(sc);
+    }
+  }
+  segments.push(seg);
+  return segments;
+};
+
+// ---------------------------------------------------------------------------
+// Wrapping: break-word mode
+// ---------------------------------------------------------------------------
+
+const wrapBreakWord = (
+  segment: StyledChar[],
+  width: number,
+  lines: StyledChar[][],
+): void => {
+  let current: StyledChar[] = [];
+  for (const sc of segment) {
+    current.push(sc);
+    if (current.length >= width) {
+      lines.push(current);
+      current = [];
+    }
+  }
+  lines.push(current);
+};
+
+// ---------------------------------------------------------------------------
+// Wrapping: word-wrap helpers
+// ---------------------------------------------------------------------------
+
+const breakLongWord = (
+  word: StyledChar[],
+  width: number,
+  lines: StyledChar[][],
+): StyledChar[] => {
+  let current: StyledChar[] = [];
+  let pos = ZERO;
+  while (pos < word.length) {
+    const chunk = word.slice(pos, pos + width);
+    if (pos + width < word.length) {
+      lines.push(chunk);
+    } else {
+      current = chunk;
+    }
+    pos += width;
+  }
+  return current;
+};
+
+const flushWord = (opts: FlushWordOptions): StyledChar[] => {
+  const { word, width, current, lines } = opts;
+  if (current.length + word.length > width) {
+    if (current.length > ZERO) {
+      lines.push(current);
+    }
+    if (word.length > width) {
+      return breakLongWord(word, width, lines);
+    }
+    return [...word];
+  }
+  current.push(...word);
+  return current;
+};
+
+/** State tracked during word-wrap processing. */
+interface WordWrapState {
+  current: StyledChar[];
+  lines: StyledChar[][];
+  pos: number;
+  segment: StyledChar[];
+  width: number;
+}
+
+const consumeWhitespace = (state: WordWrapState): void => {
+  while (state.pos < state.segment.length && isWhitespace(state.segment[state.pos].ch)) {
+    if (state.current.length < state.width) {
+      state.current.push(state.segment[state.pos]);
+    } else {
+      state.lines.push(state.current);
+      state.current = [];
+    }
+    state.pos++;
+  }
+};
+
+const collectAndFlushWord = (state: WordWrapState): void => {
+  const word: StyledChar[] = [];
+  while (state.pos < state.segment.length && !isWhitespace(state.segment[state.pos].ch)) {
+    word.push(state.segment[state.pos]);
+    state.pos++;
+  }
+  if (word.length > ZERO) {
+    state.current = flushWord({ current: state.current, lines: state.lines, width: state.width, word });
+  }
+};
+
+const wrapWordWrap = (
+  segment: StyledChar[],
+  width: number,
+  lines: StyledChar[][],
+): void => {
+  const state: WordWrapState = { current: [], lines, pos: ZERO, segment, width };
+
+  while (state.pos < segment.length) {
+    consumeWhitespace(state);
+    collectAndFlushWord(state);
+  }
+
+  lines.push(state.current);
+};
+
+// ---------------------------------------------------------------------------
+// Wrapping: main entry
+// ---------------------------------------------------------------------------
+
+const getEffectiveWidth = (maxWidth: number | undefined): number | undefined => {
+  if (maxWidth !== undefined && maxWidth > ZERO) {
+    return maxWidth;
+  }
+  return undefined;
+};
+
+/**
+ * Wrap styled characters into lines based on wrap mode and available width.
+ *
+ * Returns an array of lines, each being an array of StyledChar.
+ * If `maxWidth` is 0 or undefined, no wrapping is performed (equivalent to
+ * "no-wrap" except hard newlines are still honoured).
+ */
+export const wrapText = (
+  chars: StyledChar[],
+  wrap: TextWrap,
+  maxWidth: number | undefined,
+): StyledChar[][] => {
+  const segments = splitOnNewlines(chars);
+  const effectiveWidth = getEffectiveWidth(maxWidth);
+  const lines: StyledChar[][] = [];
+
+  for (const segment of segments) {
+    if (effectiveWidth === undefined || wrap === "no-wrap") {
+      lines.push(segment);
+    } else if (wrap === "break-word") {
+      wrapBreakWord(segment, effectiveWidth, lines);
+    } else {
+      // Word-wrap: break at word boundaries, fallback to break-word for long words
+      wrapWordWrap(segment, effectiveWidth, lines);
+    }
+  }
+
+  return lines;
+};
+
+// ---------------------------------------------------------------------------
+// Truncation
+// ---------------------------------------------------------------------------
+
+/**
+ * Truncate a line of styled characters to fit within maxWidth.
+ *
+ * When overflow is "ellipsis", the last visible character is replaced with
+ * the ellipsis character if truncation occurs.
+ */
+export const truncateLine = (
+  line: StyledChar[],
+  maxWidth: number,
+  overflow: TextOverflow,
+): StyledChar[] => {
+  if (line.length <= maxWidth) {
+    return line;
+  }
+
+  if (overflow === "ellipsis" && maxWidth > ZERO) {
+    const truncated = line.slice(ZERO, maxWidth);
+    const lastIdx = truncated.length - LAST_OFFSET;
+    const lastStyle = truncated[lastIdx].style;
+    truncated[lastIdx] = { ch: ELLIPSIS, style: lastStyle };
+    return truncated;
+  }
+
+  return line.slice(ZERO, maxWidth);
+};
+
+// ---------------------------------------------------------------------------
+// Alignment
+// ---------------------------------------------------------------------------
+
+/**
+ * Pad a line to the given width according to alignment.
+ *
+ * Adds space-styled characters on the left/right as needed. If the line is
+ * already wider than the target, it is returned unchanged.
+ */
+export const alignLine = (opts: AlignLineOptions): StyledChar[] => {
+  const { align, fillStyle, line, width } = opts;
+
+  if (line.length >= width || align === "left") {
+    return line;
+  }
+
+  const gap = width - line.length;
+  const makeSpace = (): StyledChar => ({ ch: " ", style: fillStyle });
+
+  if (align === "right") {
+    return [...Array.from({ length: gap }, makeSpace), ...line];
+  }
+
+  // Center alignment
+  const leftPad = Math.floor(gap / HALF_DIVISOR);
+  const rightPad = gap - leftPad;
+  return [
+    ...Array.from({ length: leftPad }, makeSpace),
+    ...line,
+    ...Array.from({ length: rightPad }, makeSpace),
+  ];
+};
+
+// ---------------------------------------------------------------------------
+// Text measurement
+// ---------------------------------------------------------------------------
+
+/**
+ * Measure the intrinsic size of text given wrapping constraints.
+ *
+ * This produces a width/height pair that can be fed to Taffy as intrinsic
+ * size hints for the layout node.
+ */
+export const measureText = (
+  text: string,
+  wrap: TextWrap,
+  maxWidth?: number,
+): TextMeasurement => {
+  if (text.length === ZERO) {
+    return { height: ZERO, width: ZERO };
+  }
+
+  const chars = buildStyledChars(text, {});
+  const lines = wrapText(chars, wrap, maxWidth);
+
+  let longestLine = ZERO;
+  for (const line of lines) {
+    if (line.length > longestLine) {
+      longestLine = line.length;
+    }
+  }
+
+  return { height: lines.length, width: longestLine };
+};
+
+// ---------------------------------------------------------------------------
+// TextRenderable
+// ---------------------------------------------------------------------------
+
+export class TextRenderable extends Renderable {
+  private _wrap: TextWrap = "word-wrap";
+  private _overflow: TextOverflow = "clip";
+  private _align: TextAlign = "left";
+  private _spans: TextSpan[] = [];
+
+  constructor(options?: TextOptions) {
+    super();
+    if (options) {
+      this.applyOptions(options);
+    }
+  }
+
+  private applyOptions(options: TextOptions): void {
+    if (options.text !== undefined) {
+      this.setText(options.text);
+    }
+    if (options.wrap !== undefined) {
+      this._wrap = options.wrap;
+    }
+    if (options.overflow !== undefined) {
+      this._overflow = options.overflow;
+    }
+    if (options.align !== undefined) {
+      this._align = options.align;
+    }
+    if (options.spans !== undefined) {
+      this._spans = options.spans;
+    }
+  }
+
+  // -----------------------------------------------------------------------
+  // Wrap
+  // -----------------------------------------------------------------------
+
+  get wrap(): TextWrap {
+    return this._wrap;
+  }
+
+  setWrap(wrap: TextWrap): void {
+    if (this._wrap !== wrap) {
+      this._wrap = wrap;
+      this.markDirty();
+    }
+  }
+
+  // -----------------------------------------------------------------------
+  // Overflow
+  // -----------------------------------------------------------------------
+
+  get overflow(): TextOverflow {
+    return this._overflow;
+  }
+
+  setOverflow(overflow: TextOverflow): void {
+    if (this._overflow !== overflow) {
+      this._overflow = overflow;
+      this.markDirty();
+    }
+  }
+
+  // -----------------------------------------------------------------------
+  // Alignment
+  // -----------------------------------------------------------------------
+
+  get align(): TextAlign {
+    return this._align;
+  }
+
+  setAlign(align: TextAlign): void {
+    if (this._align !== align) {
+      this._align = align;
+      this.markDirty();
+    }
+  }
+
+  // -----------------------------------------------------------------------
+  // Spans
+  // -----------------------------------------------------------------------
+
+  get spans(): readonly TextSpan[] {
+    return this._spans;
+  }
+
+  setSpans(spans: TextSpan[]): void {
+    this._spans = spans;
+    this.markDirty();
+  }
+
+  addSpan(span: TextSpan): void {
+    this._spans.push(span);
+    this.markDirty();
+  }
+
+  clearSpans(): void {
+    if (this._spans.length > ZERO) {
+      this._spans = [];
+      this.markDirty();
+    }
+  }
+
+  // -----------------------------------------------------------------------
+  // Measurement — intrinsic size for Taffy layout
+  // -----------------------------------------------------------------------
+
+  /**
+   * Measure text intrinsic size for layout.
+   *
+   * If maxWidth is provided, text is wrapped to that width. Otherwise the
+   * natural (unwrapped) width is returned.
+   */
+  measure(maxWidth?: number): TextMeasurement {
+    const content = this.text ?? "";
+    return measureText(content, this._wrap, maxWidth);
+  }
+
+  // -----------------------------------------------------------------------
+  // Rendering — produce styled character lines for output
+  // -----------------------------------------------------------------------
+
+  private renderLine(line: StyledChar[], width: number, baseStyle: TextStyle): StyledChar[] {
+    let processed = truncateLine(line, width, this._overflow);
+    processed = alignLine({ align: this._align, fillStyle: baseStyle, line: processed, width });
+    return processed;
+  }
+
+  private wrapAndProcess(content: string, width: number | undefined): StyledChar[][] {
+    const baseStyle = this.textStyle;
+    const styledChars = resolveSpans(content, baseStyle, this._spans);
+    const wrappedLines = wrapText(styledChars, this._wrap, width);
+
+    if (width === undefined || width <= ZERO) {
+      return wrappedLines;
+    }
+
+    return wrappedLines.map((line) => this.renderLine(line, width, baseStyle));
+  }
+
+  /**
+   * Render the text into lines of styled characters, applying wrapping,
+   * truncation, alignment, and inline spans.
+   *
+   * If a ComputedLayout is available (from the last layout pass), its width
+   * is used as the constraint. An explicit maxWidth overrides the layout.
+   */
+  render(maxWidth?: number): StyledChar[][] {
+    const content = this.text ?? "";
+    if (content.length === ZERO) {
+      return [];
+    }
+
+    const width = maxWidth ?? this.layout?.width;
+    return this.wrapAndProcess(content, width);
+  }
+
+  // -----------------------------------------------------------------------
+  // Lifecycle
+  // -----------------------------------------------------------------------
+
+  override onLayout(layout: ComputedLayout): void {
+    // Re-measure is implicit — layout width drives wrapping in render().
+    super.onLayout(layout);
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `TextRenderable` class extending `Renderable` base class from #24
- Text wrapping modes: `word-wrap`, `break-word`, `no-wrap` with hard newline support
- Text truncation with `clip` and `ellipsis` overflow modes
- Inline styling spans for bold, italic, color, and other `TextStyle` attributes within text
- Text alignment: `left`, `center`, `right`
- `measureText()` for feeding intrinsic size to Taffy layout engine
- Pure helper functions exported: `resolveSpans`, `wrapText`, `truncateLine`, `alignLine`, `measureText`

## Test plan
- [x] 47 tests covering all features: span resolution, wrapping modes, truncation, alignment, measurement, and full TextRenderable API
- [x] `bun test packages/core/src/text.test.ts` passes
- [x] `oxlint` passes with 0 warnings on `text.ts` and `index.ts`
- [x] TypeScript typecheck passes for `@kittyui/core`

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)