### PR TITLE
[#25] Core event system

### DIFF
--- a/packages/core/src/event-emitter.test.ts
+++ b/packages/core/src/event-emitter.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from "bun:test";
+import { EventEmitter } from "./event-emitter.js";
+
+interface TestEvents {
+  click: { x: number; y: number };
+  resize: { cols: number; rows: number };
+  close: void;
+}
+
+describe("EventEmitter", () => {
+  it("calls listeners on emit", () => {
+    const emitter = new EventEmitter<TestEvents>();
+    const results: Array<{ x: number; y: number }> = [];
+    emitter.on("click", (e) => results.push(e));
+    emitter.emit("click", { x: 10, y: 20 });
+    expect(results).toEqual([{ x: 10, y: 20 }]);
+  });
+
+  it("calls multiple listeners in order", () => {
+    const emitter = new EventEmitter<TestEvents>();
+    const order: number[] = [];
+    emitter.on("click", () => order.push(1));
+    emitter.on("click", () => order.push(2));
+    emitter.on("click", () => order.push(3));
+    emitter.emit("click", { x: 0, y: 0 });
+    expect(order).toEqual([1, 2, 3]);
+  });
+
+  it("does not cross-emit between event types", () => {
+    const emitter = new EventEmitter<TestEvents>();
+    let clickCalled = false;
+    let resizeCalled = false;
+    emitter.on("click", () => { clickCalled = true; });
+    emitter.on("resize", () => { resizeCalled = true; });
+    emitter.emit("click", { x: 0, y: 0 });
+    expect(clickCalled).toBe(true);
+    expect(resizeCalled).toBe(false);
+  });
+
+  it("on() returns a dispose function", () => {
+    const emitter = new EventEmitter<TestEvents>();
+    let count = 0;
+    const dispose = emitter.on("click", () => { count++; });
+    emitter.emit("click", { x: 0, y: 0 });
+    expect(count).toBe(1);
+    dispose();
+    emitter.emit("click", { x: 0, y: 0 });
+    expect(count).toBe(1);
+  });
+
+  it("off() removes a listener", () => {
+    const emitter = new EventEmitter<TestEvents>();
+    let count = 0;
+    const handler = () => { count++; };
+    emitter.on("click", handler);
+    emitter.off("click", handler);
+    emitter.emit("click", { x: 0, y: 0 });
+    expect(count).toBe(0);
+  });
+
+  it("off() is a no-op for unknown listener", () => {
+    const emitter = new EventEmitter<TestEvents>();
+    emitter.off("click", () => {});
+    // Should not throw
+  });
+
+  it("once() fires only once", () => {
+    const emitter = new EventEmitter<TestEvents>();
+    let count = 0;
+    emitter.once("click", () => { count++; });
+    emitter.emit("click", { x: 0, y: 0 });
+    emitter.emit("click", { x: 0, y: 0 });
+    expect(count).toBe(1);
+  });
+
+  it("once() returns a dispose function that prevents firing", () => {
+    const emitter = new EventEmitter<TestEvents>();
+    let count = 0;
+    const dispose = emitter.once("click", () => { count++; });
+    dispose();
+    emitter.emit("click", { x: 0, y: 0 });
+    expect(count).toBe(0);
+  });
+
+  it("removeAllListeners() clears specific event", () => {
+    const emitter = new EventEmitter<TestEvents>();
+    let clickCount = 0;
+    let resizeCount = 0;
+    emitter.on("click", () => { clickCount++; });
+    emitter.on("resize", () => { resizeCount++; });
+    emitter.removeAllListeners("click");
+    emitter.emit("click", { x: 0, y: 0 });
+    emitter.emit("resize", { cols: 80, rows: 24 });
+    expect(clickCount).toBe(0);
+    expect(resizeCount).toBe(1);
+  });
+
+  it("removeAllListeners() with no arg clears everything", () => {
+    const emitter = new EventEmitter<TestEvents>();
+    let count = 0;
+    emitter.on("click", () => { count++; });
+    emitter.on("resize", () => { count++; });
+    emitter.removeAllListeners();
+    emitter.emit("click", { x: 0, y: 0 });
+    emitter.emit("resize", { cols: 80, rows: 24 });
+    expect(count).toBe(0);
+  });
+
+  it("listenerCount() returns correct count", () => {
+    const emitter = new EventEmitter<TestEvents>();
+    expect(emitter.listenerCount("click")).toBe(0);
+    const dispose = emitter.on("click", () => {});
+    emitter.on("click", () => {});
+    expect(emitter.listenerCount("click")).toBe(2);
+    dispose();
+    expect(emitter.listenerCount("click")).toBe(1);
+  });
+
+  it("emit is safe when no listeners exist", () => {
+    const emitter = new EventEmitter<TestEvents>();
+    // Should not throw
+    emitter.emit("click", { x: 0, y: 0 });
+  });
+
+  it("listener can add new listeners during emit", () => {
+    const emitter = new EventEmitter<TestEvents>();
+    let secondCalled = false;
+    emitter.on("click", () => {
+      emitter.on("click", () => { secondCalled = true; });
+    });
+    emitter.emit("click", { x: 0, y: 0 });
+    // New listener should NOT be called during this emit (snapshot)
+    expect(secondCalled).toBe(false);
+    // But should fire on next emit
+    emitter.emit("click", { x: 0, y: 0 });
+    expect(secondCalled).toBe(true);
+  });
+});

--- a/packages/core/src/event-emitter.ts
+++ b/packages/core/src/event-emitter.ts
@@ -1,0 +1,120 @@
+/**
+ * EventEmitter — a lightweight, typed event emitter for terminal events.
+ *
+ * Supports adding/removing listeners, one-shot listeners, and
+ * emitting events to all registered handlers in order.
+ */
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** A listener callback. */
+export type Listener<Payload> = (event: Payload) => void;
+
+/** Constraint for event maps: string keys to any payload type. */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type EventMap = Record<string, any>;
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const NOT_FOUND = -1;
+const SPLICE_DELETE_COUNT = 1;
+const EMPTY_COUNT = 0;
+
+// ---------------------------------------------------------------------------
+// EventEmitter
+// ---------------------------------------------------------------------------
+
+export class EventEmitter<Events extends EventMap> {
+  private listeners = new Map<keyof Events, { fn: Listener<never>; once: boolean }[]>();
+
+  /**
+   * Register a listener for the given event.
+   * Returns a dispose function to remove the listener.
+   */
+  on<EventKey extends keyof Events>(event: EventKey, fn: Listener<Events[EventKey]>): () => void {
+    this.addEntry(event, fn as Listener<never>, false);
+    return () => this.off(event, fn);
+  }
+
+  /**
+   * Register a one-shot listener that auto-removes after the first call.
+   */
+  once<EventKey extends keyof Events>(event: EventKey, fn: Listener<Events[EventKey]>): () => void {
+    this.addEntry(event, fn as Listener<never>, true);
+    return () => this.off(event, fn);
+  }
+
+  /**
+   * Remove a specific listener.
+   */
+  off<EventKey extends keyof Events>(event: EventKey, fn: Listener<Events[EventKey]>): void {
+    const entries = this.listeners.get(event);
+    if (!entries) {
+      return;
+    }
+    const idx = entries.findIndex((entry) => entry.fn === fn);
+    if (idx !== NOT_FOUND) {
+      entries.splice(idx, SPLICE_DELETE_COUNT);
+    }
+    if (entries.length === EMPTY_COUNT) {
+      this.listeners.delete(event);
+    }
+  }
+
+  /**
+   * Emit an event, calling all listeners in registration order.
+   */
+  emit<EventKey extends keyof Events>(event: EventKey, payload: Events[EventKey]): void {
+    const entries = this.listeners.get(event);
+    if (!entries) {
+      return;
+    }
+    // Snapshot to allow mutations during iteration
+    const snapshot = [...entries];
+    for (const entry of snapshot) {
+      if (entry.once) {
+        this.off(event, entry.fn as Listener<Events[EventKey]>);
+      }
+      (entry.fn as Listener<Events[EventKey]>)(payload);
+    }
+  }
+
+  /**
+   * Remove all listeners, optionally for a specific event.
+   */
+  removeAllListeners<EventKey extends keyof Events>(event?: EventKey): void {
+    if (event !== undefined) {
+      this.listeners.delete(event);
+    } else {
+      this.listeners.clear();
+    }
+  }
+
+  /**
+   * Get the number of listeners for a given event.
+   */
+  listenerCount<EventKey extends keyof Events>(event: EventKey): number {
+    return this.listeners.get(event)?.length ?? EMPTY_COUNT;
+  }
+
+  // -----------------------------------------------------------------------
+  // Internal
+  // -----------------------------------------------------------------------
+
+  private addEntry<EventKey extends keyof Events>(
+    event: EventKey,
+    fn: Listener<never>,
+    once: boolean,
+  ): void {
+    let entries = this.listeners.get(event);
+    if (!entries) {
+      entries = [];
+      this.listeners.set(event, entries);
+    }
+    entries.push({ fn, once });
+  }
+}

--- a/packages/core/src/event-system.test.ts
+++ b/packages/core/src/event-system.test.ts
@@ -1,0 +1,471 @@
+import { describe, expect, it, beforeEach } from "bun:test";
+import { Renderable, resetNodeIdCounter } from "./renderable.js";
+import { RenderableTree } from "./renderable-tree.js";
+import { MutationEncoder } from "./mutation-encoder.js";
+import { EventSystem } from "./event-system.js";
+import type { SyntheticMouseEvent } from "./synthetic-event.js";
+import type { SyntheticKeyboardEvent } from "./synthetic-event.js";
+import type { SyntheticFocusEvent } from "./synthetic-event.js";
+import type { SyntheticResizeEvent } from "./synthetic-event.js";
+import type { HitResult, Modifiers } from "./types.js";
+import type { DispatchMouseOptions } from "./event-system.js";
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+class TestRenderable extends Renderable {}
+
+const NO_MODIFIERS: Modifiers = { shift: false, alt: false, ctrl: false, super: false };
+
+const mouseOpts = (overrides: Partial<DispatchMouseOptions> = {}): DispatchMouseOptions => ({
+  button: "left",
+  kind: "press",
+  col: 8,
+  row: 8,
+  pixelX: 80,
+  pixelY: 80,
+  modifiers: NO_MODIFIERS,
+  ...overrides,
+});
+
+/** Create a simple tree: root -> child -> grandchild, with layouts assigned. */
+const buildTestTree = () => {
+  const encoder = new MutationEncoder();
+  const tree = new RenderableTree(encoder);
+
+  const root = new TestRenderable();
+  const child = new TestRenderable();
+  const grandchild = new TestRenderable();
+
+  tree.setRoot(root);
+  tree.appendChild(root.nodeId, child);
+  tree.appendChild(child.nodeId, grandchild);
+
+  root.updateLayout({ x: 0, y: 0, width: 80, height: 24 });
+  child.updateLayout({ x: 5, y: 5, width: 20, height: 10 });
+  grandchild.updateLayout({ x: 7, y: 7, width: 10, height: 5 });
+
+  return { tree, root, child, grandchild };
+};
+
+describe("EventSystem", () => {
+  let tree: RenderableTree;
+  let root: TestRenderable;
+  let child: TestRenderable;
+  let grandchild: TestRenderable;
+  let eventSystem: EventSystem;
+
+  beforeEach(() => {
+    resetNodeIdCounter();
+    const built = buildTestTree();
+    tree = built.tree;
+    root = built.root;
+    child = built.child;
+    grandchild = built.grandchild;
+
+    const defaultHitTest = (_col: number, _row: number): HitResult | undefined => ({
+      target: grandchild.nodeId,
+      path: [grandchild.nodeId, child.nodeId, root.nodeId],
+    });
+
+    eventSystem = new EventSystem(tree, defaultHitTest);
+  });
+
+  // -----------------------------------------------------------------------
+  // Mouse events — basic dispatch
+  // -----------------------------------------------------------------------
+
+  describe("mouse dispatch", () => {
+    it("fires mousedown on target node", () => {
+      let received: SyntheticMouseEvent | undefined;
+      eventSystem.on(grandchild.nodeId, "mousedown", (ev) => { received = ev; });
+      eventSystem.dispatchMouse(mouseOpts());
+      expect(received).toBeDefined();
+      expect(received!.type).toBe("mousedown");
+      expect(received!.target).toBe(grandchild.nodeId);
+      expect(received!.button).toBe("left");
+    });
+
+    it("fires mouseup on release", () => {
+      let received: SyntheticMouseEvent | undefined;
+      eventSystem.on(grandchild.nodeId, "mouseup", (ev) => { received = ev; });
+      eventSystem.dispatchMouse(mouseOpts({ kind: "release" }));
+      expect(received).toBeDefined();
+      expect(received!.type).toBe("mouseup");
+    });
+
+    it("fires click on release with none button", () => {
+      let received: SyntheticMouseEvent | undefined;
+      eventSystem.on(grandchild.nodeId, "click", (ev) => { received = ev; });
+      eventSystem.dispatchMouse(mouseOpts({ button: "none", kind: "release" }));
+      expect(received).toBeDefined();
+      expect(received!.type).toBe("click");
+    });
+
+    it("fires mousemove on move", () => {
+      let received: SyntheticMouseEvent | undefined;
+      eventSystem.on(grandchild.nodeId, "mousemove", (ev) => { received = ev; });
+      eventSystem.dispatchMouse(mouseOpts({ button: "none", kind: "move" }));
+      expect(received).toBeDefined();
+      expect(received!.type).toBe("mousemove");
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Event bubbling
+  // -----------------------------------------------------------------------
+
+  describe("bubbling", () => {
+    it("events bubble from target to root", () => {
+      const order: number[] = [];
+      eventSystem.on(grandchild.nodeId, "mousedown", () => order.push(grandchild.nodeId));
+      eventSystem.on(child.nodeId, "mousedown", () => order.push(child.nodeId));
+      eventSystem.on(root.nodeId, "mousedown", () => order.push(root.nodeId));
+
+      eventSystem.dispatchMouse(mouseOpts());
+      expect(order).toEqual([grandchild.nodeId, child.nodeId, root.nodeId]);
+    });
+
+    it("sets currentTarget correctly during bubbling", () => {
+      const targets: number[] = [];
+      eventSystem.on(grandchild.nodeId, "mousedown", (ev) => targets.push(ev.currentTarget));
+      eventSystem.on(child.nodeId, "mousedown", (ev) => targets.push(ev.currentTarget));
+      eventSystem.on(root.nodeId, "mousedown", (ev) => targets.push(ev.currentTarget));
+
+      eventSystem.dispatchMouse(mouseOpts());
+      expect(targets).toEqual([grandchild.nodeId, child.nodeId, root.nodeId]);
+    });
+
+    it("stopPropagation prevents further bubbling", () => {
+      const order: number[] = [];
+      eventSystem.on(grandchild.nodeId, "mousedown", (ev) => {
+        order.push(grandchild.nodeId);
+        ev.stopPropagation();
+      });
+      eventSystem.on(child.nodeId, "mousedown", () => order.push(child.nodeId));
+      eventSystem.on(root.nodeId, "mousedown", () => order.push(root.nodeId));
+
+      eventSystem.dispatchMouse(mouseOpts());
+      expect(order).toEqual([grandchild.nodeId]);
+    });
+
+    it("stopPropagation at intermediate node prevents root from receiving", () => {
+      const order: number[] = [];
+      eventSystem.on(grandchild.nodeId, "mousedown", () => order.push(grandchild.nodeId));
+      eventSystem.on(child.nodeId, "mousedown", (ev) => {
+        order.push(child.nodeId);
+        ev.stopPropagation();
+      });
+      eventSystem.on(root.nodeId, "mousedown", () => order.push(root.nodeId));
+
+      eventSystem.dispatchMouse(mouseOpts());
+      expect(order).toEqual([grandchild.nodeId, child.nodeId]);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Event delegation
+  // -----------------------------------------------------------------------
+
+  describe("delegation", () => {
+    it("delegation handlers fire for all events", () => {
+      let received: SyntheticMouseEvent | undefined;
+      eventSystem.delegate("mousedown", (ev) => { received = ev; });
+      eventSystem.dispatchMouse(mouseOpts());
+      expect(received).toBeDefined();
+      expect(received!.target).toBe(grandchild.nodeId);
+    });
+
+    it("delegation dispose works", () => {
+      let count = 0;
+      const dispose = eventSystem.delegate("mousedown", () => { count++; });
+      eventSystem.dispatchMouse(mouseOpts());
+      expect(count).toBe(1);
+      dispose();
+      eventSystem.dispatchMouse(mouseOpts());
+      expect(count).toBe(1);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Hover tracking
+  // -----------------------------------------------------------------------
+
+  describe("hover tracking", () => {
+    it("tracks hovered node on mousemove", () => {
+      expect(eventSystem.hoveredNode).toBeUndefined();
+      eventSystem.dispatchMouse(mouseOpts({ button: "none", kind: "move" }));
+      expect(eventSystem.hoveredNode).toBe(grandchild.nodeId);
+    });
+
+    it("fires mouseenter when hovering a new node", () => {
+      let entered: SyntheticMouseEvent | undefined;
+      eventSystem.on(grandchild.nodeId, "mouseenter", (ev) => { entered = ev; });
+      eventSystem.dispatchMouse(mouseOpts({ button: "none", kind: "move" }));
+      expect(entered).toBeDefined();
+      expect(entered!.type).toBe("mouseenter");
+      expect(entered!.target).toBe(grandchild.nodeId);
+    });
+
+    it("fires mouseleave when leaving a node", () => {
+      // Use a mutable hit target for this test
+      let hitTarget: number;
+      const mutableHitTest = () => ({
+        target: hitTarget,
+        path: hitTarget === grandchild.nodeId
+          ? [grandchild.nodeId, child.nodeId, root.nodeId]
+          : [child.nodeId, root.nodeId],
+      });
+
+      resetNodeIdCounter();
+      const built = buildTestTree();
+      const sys = new EventSystem(built.tree, mutableHitTest);
+
+      let leaveReceived: SyntheticMouseEvent | undefined;
+      let enterReceived: SyntheticMouseEvent | undefined;
+      sys.on(built.grandchild.nodeId, "mouseleave", (ev) => { leaveReceived = ev; });
+      sys.on(built.child.nodeId, "mouseenter", (ev) => { enterReceived = ev; });
+
+      // First move: enter grandchild
+      hitTarget = built.grandchild.nodeId;
+      sys.dispatchMouse(mouseOpts({ button: "none", kind: "move" }));
+      expect(sys.hoveredNode).toBe(built.grandchild.nodeId);
+
+      // Second move: switch to child
+      hitTarget = built.child.nodeId;
+      sys.dispatchMouse(mouseOpts({ button: "none", kind: "move", col: 6, row: 6 }));
+      expect(sys.hoveredNode).toBe(built.child.nodeId);
+      expect(leaveReceived).toBeDefined();
+      expect(leaveReceived!.type).toBe("mouseleave");
+      expect(enterReceived).toBeDefined();
+      expect(enterReceived!.type).toBe("mouseenter");
+    });
+
+    it("does not fire enter/leave when hovering same node", () => {
+      let enterCount = 0;
+      eventSystem.on(grandchild.nodeId, "mouseenter", () => { enterCount++; });
+
+      eventSystem.dispatchMouse(mouseOpts({ button: "none", kind: "move" }));
+      eventSystem.dispatchMouse(mouseOpts({ button: "none", kind: "move", col: 9, row: 9 }));
+
+      expect(enterCount).toBe(1);
+    });
+
+    it("delegation receives mouseenter/mouseleave", () => {
+      let enterCount = 0;
+      eventSystem.delegate("mouseenter", () => { enterCount++; });
+      eventSystem.dispatchMouse(mouseOpts({ button: "none", kind: "move" }));
+      expect(enterCount).toBe(1);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Keyboard events
+  // -----------------------------------------------------------------------
+
+  describe("keyboard dispatch", () => {
+    it("fires keydown on focused node", () => {
+      let received: SyntheticKeyboardEvent | undefined;
+      eventSystem.on(child.nodeId, "keydown", (ev) => { received = ev; });
+      eventSystem.dispatchKeyboard({
+        focusedNodeId: child.nodeId,
+        key: { type: "char", char: "a" },
+        modifiers: NO_MODIFIERS,
+        eventType: "press",
+      });
+      expect(received).toBeDefined();
+      expect(received!.type).toBe("keydown");
+      expect(received!.key).toEqual({ type: "char", char: "a" });
+    });
+
+    it("keyboard events bubble up the tree", () => {
+      const order: number[] = [];
+      eventSystem.on(grandchild.nodeId, "keydown", () => order.push(grandchild.nodeId));
+      eventSystem.on(child.nodeId, "keydown", () => order.push(child.nodeId));
+      eventSystem.on(root.nodeId, "keydown", () => order.push(root.nodeId));
+
+      eventSystem.dispatchKeyboard({
+        focusedNodeId: grandchild.nodeId,
+        key: { type: "enter" },
+        modifiers: NO_MODIFIERS,
+        eventType: "press",
+      });
+      expect(order).toEqual([grandchild.nodeId, child.nodeId, root.nodeId]);
+    });
+
+    it("stopPropagation works for keyboard events", () => {
+      const order: number[] = [];
+      eventSystem.on(grandchild.nodeId, "keydown", (ev) => {
+        order.push(grandchild.nodeId);
+        ev.stopPropagation();
+      });
+      eventSystem.on(child.nodeId, "keydown", () => order.push(child.nodeId));
+
+      eventSystem.dispatchKeyboard({
+        focusedNodeId: grandchild.nodeId,
+        key: { type: "enter" },
+        modifiers: NO_MODIFIERS,
+        eventType: "press",
+      });
+      expect(order).toEqual([grandchild.nodeId]);
+    });
+
+    it("maps repeat to keypress", () => {
+      let received: SyntheticKeyboardEvent | undefined;
+      eventSystem.on(child.nodeId, "keypress", (ev) => { received = ev; });
+      eventSystem.dispatchKeyboard({
+        focusedNodeId: child.nodeId,
+        key: { type: "char", char: "x" },
+        modifiers: NO_MODIFIERS,
+        eventType: "repeat",
+      });
+      expect(received).toBeDefined();
+      expect(received!.type).toBe("keypress");
+    });
+
+    it("maps release to keyup", () => {
+      let received: SyntheticKeyboardEvent | undefined;
+      eventSystem.on(child.nodeId, "keyup", (ev) => { received = ev; });
+      eventSystem.dispatchKeyboard({
+        focusedNodeId: child.nodeId,
+        key: { type: "char", char: "x" },
+        modifiers: NO_MODIFIERS,
+        eventType: "release",
+      });
+      expect(received).toBeDefined();
+      expect(received!.type).toBe("keyup");
+    });
+
+    it("delegation receives keyboard events", () => {
+      let received: SyntheticKeyboardEvent | undefined;
+      eventSystem.delegate("keydown", (ev) => { received = ev; });
+      eventSystem.dispatchKeyboard({
+        focusedNodeId: child.nodeId,
+        key: { type: "tab" },
+        modifiers: NO_MODIFIERS,
+        eventType: "press",
+      });
+      expect(received).toBeDefined();
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Focus events
+  // -----------------------------------------------------------------------
+
+  describe("focus dispatch", () => {
+    it("fires focus on target node", () => {
+      let received: SyntheticFocusEvent | undefined;
+      eventSystem.on(child.nodeId, "focus", (ev) => { received = ev; });
+      eventSystem.dispatchFocus("focus", child.nodeId);
+      expect(received).toBeDefined();
+      expect(received!.type).toBe("focus");
+      expect(received!.target).toBe(child.nodeId);
+    });
+
+    it("fires blur on target node", () => {
+      let received: SyntheticFocusEvent | undefined;
+      eventSystem.on(child.nodeId, "blur", (ev) => { received = ev; });
+      eventSystem.dispatchFocus("blur", child.nodeId);
+      expect(received).toBeDefined();
+      expect(received!.type).toBe("blur");
+    });
+
+    it("focus events do not bubble", () => {
+      let rootReceived = false;
+      eventSystem.on(root.nodeId, "focus", () => { rootReceived = true; });
+      eventSystem.dispatchFocus("focus", child.nodeId);
+      expect(rootReceived).toBe(false);
+    });
+
+    it("delegation receives focus events", () => {
+      let received: SyntheticFocusEvent | undefined;
+      eventSystem.delegate("focus", (ev) => { received = ev; });
+      eventSystem.dispatchFocus("focus", child.nodeId);
+      expect(received).toBeDefined();
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Resize events
+  // -----------------------------------------------------------------------
+
+  describe("resize dispatch", () => {
+    it("fires resize through delegation", () => {
+      let received: SyntheticResizeEvent | undefined;
+      eventSystem.delegate("resize", (ev) => { received = ev; });
+      eventSystem.dispatchResize({ cols: 80, rows: 24, pixelWidth: 640, pixelHeight: 480 });
+      expect(received).toBeDefined();
+      expect(received!.cols).toBe(80);
+      expect(received!.rows).toBe(24);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Cleanup
+  // -----------------------------------------------------------------------
+
+  describe("cleanup", () => {
+    it("removeNode clears handlers for a node", () => {
+      let count = 0;
+      eventSystem.on(grandchild.nodeId, "mousedown", () => { count++; });
+      eventSystem.removeNode(grandchild.nodeId);
+      eventSystem.dispatchMouse(mouseOpts());
+      expect(count).toBe(0);
+    });
+
+    it("removeNode clears hover state if node was hovered", () => {
+      eventSystem.dispatchMouse(mouseOpts({ button: "none", kind: "move" }));
+      expect(eventSystem.hoveredNode).toBe(grandchild.nodeId);
+      eventSystem.removeNode(grandchild.nodeId);
+      expect(eventSystem.hoveredNode).toBeUndefined();
+    });
+
+    it("dispose clears everything", () => {
+      let count = 0;
+      eventSystem.on(grandchild.nodeId, "mousedown", () => { count++; });
+      eventSystem.delegate("mousedown", () => { count++; });
+      eventSystem.dispatchMouse(mouseOpts({ button: "none", kind: "move" }));
+
+      eventSystem.dispose();
+
+      eventSystem.dispatchMouse(mouseOpts());
+      expect(count).toBe(0);
+      expect(eventSystem.hoveredNode).toBeUndefined();
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Hit test returns undefined (nothing hit)
+  // -----------------------------------------------------------------------
+
+  describe("miss hit test", () => {
+    it("handles hit test returning undefined", () => {
+      const missSystem = new EventSystem(tree, () => undefined);
+      let delegateReceived = false;
+      missSystem.delegate("mousedown", () => { delegateReceived = true; });
+      missSystem.dispatchMouse(mouseOpts());
+      expect(delegateReceived).toBe(true);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // off() removes handler
+  // -----------------------------------------------------------------------
+
+  describe("off", () => {
+    it("removes a specific handler from a node", () => {
+      let count = 0;
+      const handler = () => { count++; };
+      eventSystem.on(grandchild.nodeId, "mousedown", handler);
+      eventSystem.off(grandchild.nodeId, "mousedown", handler);
+      eventSystem.dispatchMouse(mouseOpts());
+      expect(count).toBe(0);
+    });
+
+    it("off on non-existent node is a no-op", () => {
+      eventSystem.off(999, "mousedown", () => {});
+    });
+  });
+});

--- a/packages/core/src/event-system.ts
+++ b/packages/core/src/event-system.ts
@@ -1,0 +1,474 @@
+/**
+ * EventSystem — orchestrates event dispatch, bubbling, delegation, and
+ * hover state tracking for the renderable tree.
+ *
+ * The EventSystem sits at the root level and:
+ * 1. Receives raw terminal events
+ * 2. Performs hit-testing to find the target node
+ * 3. Creates SyntheticEvents
+ * 4. Bubbles events up the renderable tree (target -> root)
+ * 5. Tracks hover state to emit mouseenter/mouseleave
+ * 6. Supports event delegation via root-level handlers
+ */
+
+import { EventEmitter, type EventMap, type Listener } from "./event-emitter.js";
+import { type AnySyntheticEvent, type MouseEventInit as MouseEventInitType, SyntheticFocusEvent, SyntheticKeyboardEvent, type SyntheticKeyboardEventType, SyntheticMouseEvent, type SyntheticMouseEventType, SyntheticResizeEvent } from "./synthetic-event.js";
+import { type HitResult, type Key, type KeyEventType, type Modifiers, type MouseButton, type MouseEventKind } from "./types.js";
+import { type Renderable } from "./renderable.js";
+import { type RenderableTree } from "./renderable-tree.js";
+
+// ---------------------------------------------------------------------------
+// Event handler types
+// ---------------------------------------------------------------------------
+
+export type MouseHandler = (event: SyntheticMouseEvent) => void;
+export type KeyboardHandler = (event: SyntheticKeyboardEvent) => void;
+export type FocusHandler = (event: SyntheticFocusEvent) => void;
+export type ResizeHandler = (event: SyntheticResizeEvent) => void;
+
+// ---------------------------------------------------------------------------
+// Node-level event map
+// ---------------------------------------------------------------------------
+
+export interface NodeEventMap extends EventMap {
+  blur: SyntheticFocusEvent;
+  click: SyntheticMouseEvent;
+  focus: SyntheticFocusEvent;
+  keydown: SyntheticKeyboardEvent;
+  keypress: SyntheticKeyboardEvent;
+  keyup: SyntheticKeyboardEvent;
+  mousedown: SyntheticMouseEvent;
+  mouseenter: SyntheticMouseEvent;
+  mouseleave: SyntheticMouseEvent;
+  mousemove: SyntheticMouseEvent;
+  mouseup: SyntheticMouseEvent;
+  resize: SyntheticResizeEvent;
+}
+
+// ---------------------------------------------------------------------------
+// Hit test provider
+// ---------------------------------------------------------------------------
+
+/**
+ * Function that performs a hit test at (col, row) and returns the target node
+ * and its ancestor path for bubbling. If nothing is hit, returns undefined.
+ */
+export type HitTestFn = (col: number, row: number) => HitResult | undefined;
+
+// ---------------------------------------------------------------------------
+// Dispatch options
+// ---------------------------------------------------------------------------
+
+export interface DispatchMouseOptions {
+  button: MouseButton;
+  col: number;
+  kind: MouseEventKind;
+  modifiers: Modifiers;
+  pixelX: number;
+  pixelY: number;
+  row: number;
+}
+
+export interface DispatchKeyboardOptions {
+  eventType: KeyEventType;
+  focusedNodeId: number;
+  key: Key;
+  modifiers: Modifiers;
+}
+
+export interface DispatchResizeOptions {
+  cols: number;
+  pixelHeight: number;
+  pixelWidth: number;
+  rows: number;
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const ROOT_TARGET = 0;
+
+type HoverBaseInit = Omit<MouseEventInitType, "target" | "type">;
+
+interface BubblePath {
+  path: number[];
+  target: number;
+}
+
+// ---------------------------------------------------------------------------
+// EventSystem
+// ---------------------------------------------------------------------------
+
+export class EventSystem {
+  private tree: RenderableTree;
+  private hitTest: HitTestFn;
+
+  /** Per-node event emitters, keyed by node ID. */
+  private nodeEmitters = new Map<number, EventEmitter<NodeEventMap>>();
+
+  /** Root-level delegation handlers (receive all events before bubbling). */
+  private delegationEmitter = new EventEmitter<NodeEventMap>();
+
+  /** The node ID currently hovered (for mouseenter/mouseleave). */
+  private hoveredNodeId: number | undefined;
+
+  constructor(tree: RenderableTree, hitTest: HitTestFn) {
+    this.tree = tree;
+    this.hitTest = hitTest;
+  }
+
+  // -----------------------------------------------------------------------
+  // Node-level event registration
+  // -----------------------------------------------------------------------
+
+  /**
+   * Register a handler on a specific node.
+   * Returns a dispose function.
+   */
+  on<EventKey extends keyof NodeEventMap>(
+    nodeId: number,
+    event: EventKey,
+    handler: Listener<NodeEventMap[EventKey]>,
+  ): () => void {
+    let emitter = this.nodeEmitters.get(nodeId);
+    if (!emitter) {
+      emitter = new EventEmitter<NodeEventMap>();
+      this.nodeEmitters.set(nodeId, emitter);
+    }
+    return emitter.on(event, handler);
+  }
+
+  /**
+   * Remove a handler from a specific node.
+   */
+  off<EventKey extends keyof NodeEventMap>(
+    nodeId: number,
+    event: EventKey,
+    handler: Listener<NodeEventMap[EventKey]>,
+  ): void {
+    const emitter = this.nodeEmitters.get(nodeId);
+    if (emitter) {
+      emitter.off(event, handler);
+    }
+  }
+
+  // -----------------------------------------------------------------------
+  // Root-level delegation
+  // -----------------------------------------------------------------------
+
+  /**
+   * Register a delegation handler at the root level.
+   * Delegation handlers fire for ALL events of a given type,
+   * regardless of which node is targeted.
+   */
+  delegate<EventKey extends keyof NodeEventMap>(
+    event: EventKey,
+    handler: Listener<NodeEventMap[EventKey]>,
+  ): () => void {
+    return this.delegationEmitter.on(event, handler);
+  }
+
+  // -----------------------------------------------------------------------
+  // Event dispatch — Mouse
+  // -----------------------------------------------------------------------
+
+  /**
+   * Dispatch a raw mouse event through the system.
+   * Performs hit-testing, creates synthetic events, handles hover tracking,
+   * and bubbles events up the tree.
+   */
+  dispatchMouse(opts: DispatchMouseOptions): void {
+    const hit = this.hitTest(opts.col, opts.row);
+    const target = hit?.target ?? ROOT_TARGET;
+    const path = hit?.path ?? [];
+
+    const eventType = mouseKindToEventType(opts.kind, opts.button);
+
+    const syntheticEvent = new SyntheticMouseEvent({
+      button: opts.button,
+      col: opts.col,
+      kind: opts.kind,
+      modifiers: opts.modifiers,
+      pixelX: opts.pixelX,
+      pixelY: opts.pixelY,
+      row: opts.row,
+      target,
+      type: eventType,
+    });
+
+    // Hover tracking (mouseenter / mouseleave)
+    if (opts.kind === "move") {
+      this.updateHover(target, opts);
+    }
+
+    // Delegation (root-level)
+    this.delegationEmitter.emit(eventType, syntheticEvent);
+
+    // Bubble: target -> ancestors -> root
+    this.bubble(eventType, syntheticEvent, { path, target });
+  }
+
+  // -----------------------------------------------------------------------
+  // Event dispatch — Keyboard
+  // -----------------------------------------------------------------------
+
+  /**
+   * Dispatch a keyboard event. Keyboard events target the focused node
+   * (provided by the caller) and bubble up.
+   */
+  dispatchKeyboard(opts: DispatchKeyboardOptions): void {
+    const synType = keyEventTypeToSyntheticType(opts.eventType);
+    const target = opts.focusedNodeId;
+    const path = this.buildPathToRoot(target);
+
+    const syntheticEvent = new SyntheticKeyboardEvent({
+      eventType: opts.eventType,
+      key: opts.key,
+      modifiers: opts.modifiers,
+      target,
+      type: synType,
+    });
+
+    this.delegationEmitter.emit(synType, syntheticEvent);
+    this.bubble(synType, syntheticEvent, { path, target });
+  }
+
+  // -----------------------------------------------------------------------
+  // Event dispatch — Focus
+  // -----------------------------------------------------------------------
+
+  /**
+   * Dispatch a focus or blur event on a node (does not bubble).
+   */
+  dispatchFocus(type: "focus" | "blur", nodeId: number): void {
+    const syntheticEvent = new SyntheticFocusEvent(type, nodeId);
+    this.delegationEmitter.emit(type, syntheticEvent);
+    // Focus events do not bubble — fire only on target
+    const emitter = this.nodeEmitters.get(nodeId);
+    if (emitter) {
+      syntheticEvent.currentTarget = nodeId;
+      emitter.emit(type, syntheticEvent);
+    }
+  }
+
+  // -----------------------------------------------------------------------
+  // Event dispatch — Resize
+  // -----------------------------------------------------------------------
+
+  /**
+   * Dispatch a resize event (fires only at root delegation level).
+   */
+  dispatchResize(opts: DispatchResizeOptions): void {
+    const syntheticEvent = new SyntheticResizeEvent({
+      cols: opts.cols,
+      pixelHeight: opts.pixelHeight,
+      pixelWidth: opts.pixelWidth,
+      rows: opts.rows,
+      target: ROOT_TARGET,
+    });
+    this.delegationEmitter.emit("resize", syntheticEvent);
+  }
+
+  // -----------------------------------------------------------------------
+  // Hover tracking
+  // -----------------------------------------------------------------------
+
+  /** Get the currently hovered node ID, or undefined if nothing is hovered. */
+  get hoveredNode(): number | undefined {
+    return this.hoveredNodeId;
+  }
+
+  // -----------------------------------------------------------------------
+  // Cleanup
+  // -----------------------------------------------------------------------
+
+  /**
+   * Remove all event handlers for a node (call when node is removed from tree).
+   */
+  removeNode(nodeId: number): void {
+    this.nodeEmitters.delete(nodeId);
+    if (this.hoveredNodeId === nodeId) {
+      this.hoveredNodeId = undefined;
+    }
+  }
+
+  /**
+   * Remove all handlers and reset state.
+   */
+  dispose(): void {
+    this.nodeEmitters.clear();
+    this.delegationEmitter.removeAllListeners();
+    this.hoveredNodeId = undefined;
+  }
+
+  // -----------------------------------------------------------------------
+  // Internal — bubbling
+  // -----------------------------------------------------------------------
+
+  private bubble<EventKey extends keyof NodeEventMap>(
+    eventType: EventKey,
+    syntheticEvent: AnySyntheticEvent,
+    bubblePath: BubblePath,
+  ): void {
+    this.fireOnNode(eventType, syntheticEvent, bubblePath.target);
+    if (syntheticEvent.isPropagationStopped) {
+      return;
+    }
+
+    for (const ancestorId of bubblePath.path) {
+      if (ancestorId !== bubblePath.target) {
+        this.fireOnNode(eventType, syntheticEvent, ancestorId);
+        if (syntheticEvent.isPropagationStopped) {
+          return;
+        }
+      }
+    }
+  }
+
+  private fireOnNode<EventKey extends keyof NodeEventMap>(
+    eventType: EventKey,
+    syntheticEvent: AnySyntheticEvent,
+    nodeId: number,
+  ): void {
+    const emitter = this.nodeEmitters.get(nodeId);
+    if (emitter) {
+      syntheticEvent.currentTarget = nodeId;
+      emitter.emit(eventType, syntheticEvent as NodeEventMap[EventKey]);
+    }
+  }
+
+  // -----------------------------------------------------------------------
+  // Internal — hover tracking
+  // -----------------------------------------------------------------------
+
+  private updateHover(newTarget: number, mouseOpts: DispatchMouseOptions): void {
+    const prevHovered = this.hoveredNodeId;
+
+    if (prevHovered === newTarget) {
+      return;
+    }
+
+    const baseInit = {
+      button: mouseOpts.button,
+      col: mouseOpts.col,
+      kind: mouseOpts.kind,
+      modifiers: mouseOpts.modifiers,
+      pixelX: mouseOpts.pixelX,
+      pixelY: mouseOpts.pixelY,
+      row: mouseOpts.row,
+    };
+
+    this.emitLeaveEvent(prevHovered, baseInit);
+    this.emitEnterEvent(newTarget, baseInit);
+
+    this.hoveredNodeId = resolveHoveredNode(newTarget);
+  }
+
+  private emitLeaveEvent(
+    prevHovered: number | undefined,
+    baseInit: HoverBaseInit,
+  ): void {
+    if (prevHovered === undefined) {
+      return;
+    }
+    const leaveEvent = new SyntheticMouseEvent({
+      ...baseInit,
+      target: prevHovered,
+      type: "mouseleave",
+    });
+    this.delegationEmitter.emit("mouseleave", leaveEvent);
+    const emitter = this.nodeEmitters.get(prevHovered);
+    if (emitter) {
+      leaveEvent.currentTarget = prevHovered;
+      emitter.emit("mouseleave", leaveEvent);
+    }
+  }
+
+  private emitEnterEvent(
+    newTarget: number,
+    baseInit: HoverBaseInit,
+  ): void {
+    if (newTarget === ROOT_TARGET) {
+      return;
+    }
+    const enterEvent = new SyntheticMouseEvent({
+      ...baseInit,
+      target: newTarget,
+      type: "mouseenter",
+    });
+    this.delegationEmitter.emit("mouseenter", enterEvent);
+    const emitter = this.nodeEmitters.get(newTarget);
+    if (emitter) {
+      enterEvent.currentTarget = newTarget;
+      emitter.emit("mouseenter", enterEvent);
+    }
+  }
+
+  // -----------------------------------------------------------------------
+  // Internal — path building
+  // -----------------------------------------------------------------------
+
+  /**
+   * Build the ancestor path from a node to the root by walking the tree.
+   * Used for keyboard events where we don't have a hit-test path.
+   */
+  private buildPathToRoot(nodeId: number): number[] {
+    const path: number[] = [nodeId];
+    let current: Renderable | undefined = this.tree.get(nodeId);
+    while (current) {
+      const parent = this.tree.parent(current.nodeId);
+      if (!parent) {
+        break;
+      }
+      path.push(parent.nodeId);
+      current = parent;
+    }
+    return path;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const mouseKindToEventType = (kind: MouseEventKind, button: MouseButton): SyntheticMouseEventType => {
+  switch (kind) {
+    case "press": {
+      return "mousedown";
+    }
+    case "release": {
+      if (button === "none") {
+        return "click";
+      }
+      return "mouseup";
+    }
+    case "move": {
+      return "mousemove";
+    }
+    case "drag": {
+      return "mousemove";
+    }
+  }
+};
+
+const resolveHoveredNode = (newTarget: number): number | undefined => {
+  if (newTarget === ROOT_TARGET) {
+    return undefined;
+  }
+  return newTarget;
+};
+
+const keyEventTypeToSyntheticType = (eventType: KeyEventType): SyntheticKeyboardEventType => {
+  switch (eventType) {
+    case "press": {
+      return "keydown";
+    }
+    case "repeat": {
+      return "keypress";
+    }
+    case "release": {
+      return "keyup";
+    }
+  }
+};

--- a/packages/core/src/synthetic-event.test.ts
+++ b/packages/core/src/synthetic-event.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, it } from "bun:test";
+import {
+  SyntheticKeyboardEvent,
+  SyntheticMouseEvent,
+  SyntheticResizeEvent,
+  SyntheticFocusEvent,
+} from "./synthetic-event.js";
+import type { Modifiers } from "./types.js";
+
+const NO_MODIFIERS: Modifiers = { shift: false, alt: false, ctrl: false, super: false };
+
+describe("SyntheticEvent", () => {
+  describe("SyntheticMouseEvent", () => {
+    it("stores mouse event properties", () => {
+      const event = new SyntheticMouseEvent({
+        type: "mousedown",
+        target: 5,
+        button: "left",
+        kind: "press",
+        col: 10,
+        row: 20,
+        pixelX: 100,
+        pixelY: 200,
+        modifiers: NO_MODIFIERS,
+      });
+      expect(event.type).toBe("mousedown");
+      expect(event.target).toBe(5);
+      expect(event.currentTarget).toBe(5);
+      expect(event.button).toBe("left");
+      expect(event.kind).toBe("press");
+      expect(event.col).toBe(10);
+      expect(event.row).toBe(20);
+      expect(event.pixelX).toBe(100);
+      expect(event.pixelY).toBe(200);
+    });
+
+    it("stopPropagation works", () => {
+      const event = new SyntheticMouseEvent({
+        type: "click",
+        target: 1,
+        button: "left",
+        kind: "release",
+        col: 0,
+        row: 0,
+        pixelX: 0,
+        pixelY: 0,
+        modifiers: NO_MODIFIERS,
+      });
+      expect(event.isPropagationStopped).toBe(false);
+      event.stopPropagation();
+      expect(event.isPropagationStopped).toBe(true);
+    });
+
+    it("preventDefault works", () => {
+      const event = new SyntheticMouseEvent({
+        type: "click",
+        target: 1,
+        button: "left",
+        kind: "release",
+        col: 0,
+        row: 0,
+        pixelX: 0,
+        pixelY: 0,
+        modifiers: NO_MODIFIERS,
+      });
+      expect(event.isDefaultPrevented).toBe(false);
+      event.preventDefault();
+      expect(event.isDefaultPrevented).toBe(true);
+    });
+
+    it("has a timestamp", () => {
+      const before = Date.now();
+      const event = new SyntheticMouseEvent({
+        type: "click",
+        target: 1,
+        button: "left",
+        kind: "release",
+        col: 0,
+        row: 0,
+        pixelX: 0,
+        pixelY: 0,
+        modifiers: NO_MODIFIERS,
+      });
+      const after = Date.now();
+      expect(event.timestamp).toBeGreaterThanOrEqual(before);
+      expect(event.timestamp).toBeLessThanOrEqual(after);
+    });
+  });
+
+  describe("SyntheticKeyboardEvent", () => {
+    it("stores keyboard event properties", () => {
+      const event = new SyntheticKeyboardEvent({
+        type: "keydown",
+        target: 3,
+        key: { type: "char", char: "a" },
+        modifiers: { shift: true, alt: false, ctrl: false, super: false },
+        eventType: "press",
+      });
+      expect(event.type).toBe("keydown");
+      expect(event.target).toBe(3);
+      expect(event.key).toEqual({ type: "char", char: "a" });
+      expect(event.modifiers.shift).toBe(true);
+      expect(event.eventType).toBe("press");
+    });
+
+    it("supports stopPropagation", () => {
+      const event = new SyntheticKeyboardEvent({
+        type: "keydown",
+        target: 1,
+        key: { type: "enter" },
+        modifiers: NO_MODIFIERS,
+        eventType: "press",
+      });
+      event.stopPropagation();
+      expect(event.isPropagationStopped).toBe(true);
+    });
+  });
+
+  describe("SyntheticResizeEvent", () => {
+    it("stores resize properties", () => {
+      const event = new SyntheticResizeEvent({
+        target: 0,
+        cols: 80,
+        rows: 24,
+        pixelWidth: 640,
+        pixelHeight: 480,
+      });
+      expect(event.type).toBe("resize");
+      expect(event.cols).toBe(80);
+      expect(event.rows).toBe(24);
+      expect(event.pixelWidth).toBe(640);
+      expect(event.pixelHeight).toBe(480);
+    });
+  });
+
+  describe("SyntheticFocusEvent", () => {
+    it("stores focus type and target", () => {
+      const focusEvent = new SyntheticFocusEvent("focus", 7);
+      expect(focusEvent.type).toBe("focus");
+      expect(focusEvent.target).toBe(7);
+
+      const blurEvent = new SyntheticFocusEvent("blur", 7);
+      expect(blurEvent.type).toBe("blur");
+    });
+  });
+
+  describe("currentTarget mutation", () => {
+    it("currentTarget can be updated during bubbling", () => {
+      const event = new SyntheticMouseEvent({
+        type: "click",
+        target: 5,
+        button: "left",
+        kind: "release",
+        col: 0,
+        row: 0,
+        pixelX: 0,
+        pixelY: 0,
+        modifiers: NO_MODIFIERS,
+      });
+      expect(event.currentTarget).toBe(5);
+      event.currentTarget = 2;
+      expect(event.currentTarget).toBe(2);
+      expect(event.target).toBe(5);
+    });
+  });
+});

--- a/packages/core/src/synthetic-event.ts
+++ b/packages/core/src/synthetic-event.ts
@@ -1,0 +1,167 @@
+/**
+ * SyntheticEvent — React-style synthetic events for the terminal.
+ *
+ * Wraps raw terminal events with:
+ * - stopPropagation() / isPropagationStopped
+ * - preventDefault() / isDefaultPrevented
+ * - target / currentTarget node IDs
+ * - event type and timestamp
+ */
+
+import type { Key, KeyEventType, Modifiers, MouseButton, MouseEventKind } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Base synthetic event
+// ---------------------------------------------------------------------------
+
+export abstract class SyntheticEvent<EventType extends string = string> {
+  readonly type: EventType;
+  readonly timestamp: number;
+
+  /** The node ID where the event originated. */
+  readonly target: number;
+
+  /** The node ID of the current handler (set during bubbling). */
+  currentTarget: number;
+
+  private _propagationStopped = false;
+  private _defaultPrevented = false;
+
+  constructor(type: EventType, target: number) {
+    this.type = type;
+    this.timestamp = Date.now();
+    this.target = target;
+    this.currentTarget = target;
+  }
+
+  stopPropagation(): void {
+    this._propagationStopped = true;
+  }
+
+  get isPropagationStopped(): boolean {
+    return this._propagationStopped;
+  }
+
+  preventDefault(): void {
+    this._defaultPrevented = true;
+  }
+
+  get isDefaultPrevented(): boolean {
+    return this._defaultPrevented;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Keyboard synthetic event
+// ---------------------------------------------------------------------------
+
+export type SyntheticKeyboardEventType = "keydown" | "keyup" | "keypress";
+
+export interface KeyboardEventInit {
+  eventType: KeyEventType;
+  key: Key;
+  modifiers: Modifiers;
+  target: number;
+  type: SyntheticKeyboardEventType;
+}
+
+export class SyntheticKeyboardEvent extends SyntheticEvent<SyntheticKeyboardEventType> {
+  readonly key: Key;
+  readonly modifiers: Modifiers;
+  readonly eventType: KeyEventType;
+
+  constructor(init: KeyboardEventInit) {
+    super(init.type, init.target);
+    this.key = init.key;
+    this.modifiers = init.modifiers;
+    this.eventType = init.eventType;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Mouse synthetic event
+// ---------------------------------------------------------------------------
+
+export type SyntheticMouseEventType =
+  | "mousedown"
+  | "mouseup"
+  | "mousemove"
+  | "click"
+  | "mouseenter"
+  | "mouseleave";
+
+export interface MouseEventInit {
+  button: MouseButton;
+  col: number;
+  kind: MouseEventKind;
+  modifiers: Modifiers;
+  pixelX: number;
+  pixelY: number;
+  row: number;
+  target: number;
+  type: SyntheticMouseEventType;
+}
+
+export class SyntheticMouseEvent extends SyntheticEvent<SyntheticMouseEventType> {
+  readonly button: MouseButton;
+  readonly kind: MouseEventKind;
+  readonly col: number;
+  readonly row: number;
+  readonly pixelX: number;
+  readonly pixelY: number;
+  readonly modifiers: Modifiers;
+
+  constructor(init: MouseEventInit) {
+    super(init.type, init.target);
+    this.button = init.button;
+    this.kind = init.kind;
+    this.col = init.col;
+    this.row = init.row;
+    this.pixelX = init.pixelX;
+    this.pixelY = init.pixelY;
+    this.modifiers = init.modifiers;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Resize synthetic event
+// ---------------------------------------------------------------------------
+
+export interface ResizeEventInit {
+  cols: number;
+  pixelHeight: number;
+  pixelWidth: number;
+  rows: number;
+  target: number;
+}
+
+export class SyntheticResizeEvent extends SyntheticEvent<"resize"> {
+  readonly cols: number;
+  readonly rows: number;
+  readonly pixelWidth: number;
+  readonly pixelHeight: number;
+
+  constructor(init: ResizeEventInit) {
+    super("resize", init.target);
+    this.cols = init.cols;
+    this.rows = init.rows;
+    this.pixelWidth = init.pixelWidth;
+    this.pixelHeight = init.pixelHeight;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Focus synthetic events
+// ---------------------------------------------------------------------------
+
+export class SyntheticFocusEvent extends SyntheticEvent<"focus" | "blur"> {}
+
+// ---------------------------------------------------------------------------
+// Union type
+// ---------------------------------------------------------------------------
+
+export type AnySyntheticEvent =
+  | SyntheticKeyboardEvent
+  | SyntheticMouseEvent
+  | SyntheticResizeEvent
+  | SyntheticFocusEvent;


### PR DESCRIPTION
## Summary
- **EventEmitter**: Typed, lightweight event emitter with `on`/`once`/`off`/`emit`, listener snapshots for safe mutation during emit, and dispose-function returns
- **SyntheticEvent**: React-style synthetic events for terminal — `SyntheticMouseEvent`, `SyntheticKeyboardEvent`, `SyntheticResizeEvent`, `SyntheticFocusEvent` with `stopPropagation()` and `preventDefault()`
- **EventSystem**: Full event orchestration — hit-test-based targeting, event bubbling (target to root), root-level event delegation, and hover state tracking (`mouseenter`/`mouseleave` derived from `mousemove` + hit test)

## Test plan
- [x] 14 tests for EventEmitter (on/off/once/emit/removeAll/listenerCount/snapshot safety)
- [x] 8 tests for SyntheticEvent (properties, stopPropagation, preventDefault, currentTarget mutation)
- [x] 32 tests for EventSystem (mouse dispatch, bubbling order, stopPropagation, delegation, hover tracking with enter/leave, keyboard dispatch with bubbling, focus events without bubbling, resize delegation, cleanup/dispose, hit-test miss handling)
- [x] All 54 tests pass with `bun test`
- [x] No typecheck errors in event files
- [x] Lint warnings minimized (1 remaining sort-imports matches existing codebase pattern)

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)