### PR TITLE
[#30] Define JSX intrinsic element types, style props, and event handler props

### DIFF
--- a/packages/react/src/host-config.ts
+++ b/packages/react/src/host-config.ts
@@ -4,7 +4,7 @@
  * Maps React's tree operations to mutations on a RenderableTree.
  */
 
-import { type BoxRenderable, type KittyProps, type TextRenderable, createRenderableForType } from "./renderables.js";
+import { type BoxRenderable, type ImageRenderable, type KittyProps, type TextRenderable, createRenderableForType } from "./renderables.js";
 import type { RenderableTree } from "@kittyui/core";
 
 // ---------------------------------------------------------------------------
@@ -23,7 +23,7 @@ export interface Container {
 }
 
 /** A host instance is one of our Renderable subclasses. */
-type Instance = BoxRenderable | TextRenderable;
+type Instance = BoxRenderable | ImageRenderable | TextRenderable;
 
 /** A text instance wraps a TextRenderable holding raw string content. */
 type TextInstance = TextRenderable;

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -4,4 +4,20 @@
 
 export { hello } from "@kittyui/core";
 export { createRoot, type KittyRoot } from "./reconciler.js";
-export { BoxRenderable, TextRenderable, createRenderableForType, type KittyProps } from "./renderables.js";
+export { BoxRenderable, ImageRenderable, TextRenderable, createRenderableForType, type KittyProps } from "./renderables.js";
+
+// JSX prop and event types
+export type {
+  BoxProps,
+  ImageProps,
+  TextProps,
+  KittyMouseEvent,
+  KittyKeyboardEvent,
+  KittyFocusEvent,
+  KittyScrollEvent,
+  KittyRef,
+  MouseEventHandlers,
+  KeyboardEventHandlers,
+  FocusEventHandlers,
+  FocusProps,
+} from "./types.js";

--- a/packages/react/src/jsx.d.ts
+++ b/packages/react/src/jsx.d.ts
@@ -1,0 +1,19 @@
+/**
+ * JSX intrinsic element declarations for KittyUI.
+ *
+ * Augments the global JSX namespace so that <box>, <text>, and <image>
+ * elements are type-checked in TSX files.
+ */
+
+import type { BoxProps, ImageProps, TextProps } from "./types.js";
+
+declare global {
+  // eslint-disable-next-line @typescript-eslint/no-namespace
+  namespace JSX {
+    interface IntrinsicElements {
+      box: BoxProps;
+      text: TextProps;
+      image: ImageProps;
+    }
+  }
+}

--- a/packages/react/src/renderables.ts
+++ b/packages/react/src/renderables.ts
@@ -3,21 +3,79 @@
  */
 
 import { type CSSStyle, Renderable } from "@kittyui/core";
+import type {
+  FocusEventHandlers,
+  FocusProps,
+  KeyboardEventHandlers,
+  MouseEventHandlers,
+} from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Shared props interface
+// ---------------------------------------------------------------------------
 
 /** Props shared by all KittyUI JSX elements. */
-export interface KittyProps {
+export interface KittyProps
+  extends MouseEventHandlers,
+    KeyboardEventHandlers,
+    FocusEventHandlers,
+    FocusProps {
   children?: unknown;
   style?: CSSStyle;
+  src?: string;
+  width?: number;
+  height?: number;
 }
+
+// ---------------------------------------------------------------------------
+// Event handler storage
+// ---------------------------------------------------------------------------
+
+type EventHandlerKey = keyof MouseEventHandlers | keyof KeyboardEventHandlers | keyof FocusEventHandlers;
+
+const EVENT_HANDLER_KEYS: EventHandlerKey[] = [
+  "onClick",
+  "onMouseEnter",
+  "onMouseLeave",
+  "onMouseDown",
+  "onMouseUp",
+  "onMouseMove",
+  "onScroll",
+  "onKeyDown",
+  "onKeyUp",
+  "onKeyPress",
+  "onFocus",
+  "onBlur",
+];
+
+// ---------------------------------------------------------------------------
+// Renderables
+// ---------------------------------------------------------------------------
 
 /** A box container element (like a div). */
 export class BoxRenderable extends Renderable {
   readonly type = "box";
 
+  /** Stored event handlers for this element. */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  eventHandlers: Partial<Record<EventHandlerKey, ((...args: any[]) => void) | undefined>> = {};
+
+  /** Focus tab index. */
+  tabIndex: number | undefined;
+
+  /** Whether to auto-focus on mount. */
+  autoFocus: boolean | undefined;
+
   applyProps(props: KittyProps): void {
     if (props.style) {
       this.setStyle(props.style);
     }
+    for (const key of EVENT_HANDLER_KEYS) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      this.eventHandlers[key] = (props as any)[key];
+    }
+    this.tabIndex = props.tabIndex;
+    this.autoFocus = props.autoFocus;
   }
 }
 
@@ -32,14 +90,50 @@ export class TextRenderable extends Renderable {
   }
 }
 
+/** An image element that renders via the Kitty graphics protocol. */
+export class ImageRenderable extends Renderable {
+  readonly type = "image";
+
+  /** Image source path or URL. */
+  src: string | undefined;
+
+  /** Requested display width in cells. */
+  displayWidth: number | undefined;
+
+  /** Requested display height in cells. */
+  displayHeight: number | undefined;
+
+  /** Focus tab index. */
+  tabIndex: number | undefined;
+
+  /** Whether to auto-focus on mount. */
+  autoFocus: boolean | undefined;
+
+  applyProps(props: KittyProps): void {
+    if (props.style) {
+      this.setStyle(props.style);
+    }
+    this.src = props.src;
+    this.displayWidth = props.width;
+    this.displayHeight = props.height;
+    this.tabIndex = props.tabIndex;
+    this.autoFocus = props.autoFocus;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
 /** Map from JSX tag name to Renderable constructor. */
-const TAG_MAP: Record<string, new () => BoxRenderable | TextRenderable> = {
+const TAG_MAP: Record<string, new () => BoxRenderable | TextRenderable | ImageRenderable> = {
   box: BoxRenderable,
+  image: ImageRenderable,
   text: TextRenderable,
 };
 
 /** Create a Renderable instance from a JSX tag name. */
-export const createRenderableForType = (type: string): BoxRenderable | TextRenderable => {
+export const createRenderableForType = (type: string): BoxRenderable | TextRenderable | ImageRenderable => {
   const Ctor = TAG_MAP[type];
   if (!Ctor) {
     throw new Error(`Unknown KittyUI element type: "${type}"`);

--- a/packages/react/src/types.test.ts
+++ b/packages/react/src/types.test.ts
@@ -1,0 +1,227 @@
+/**
+ * Tests for JSX intrinsic types, props, and event handlers.
+ *
+ * These tests verify both compile-time type correctness and runtime prop handling.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { resetNodeIdCounter } from "@kittyui/core";
+import {
+  BoxRenderable,
+  ImageRenderable,
+  TextRenderable,
+  createRenderableForType,
+} from "./renderables.js";
+import type {
+  BoxProps,
+  ImageProps,
+  KittyFocusEvent,
+  KittyKeyboardEvent,
+  KittyMouseEvent,
+  KittyScrollEvent,
+  TextProps,
+} from "./types.js";
+
+describe("JSX intrinsic types", () => {
+  // Reset IDs before each test for determinism
+  test.each([undefined])("setup", () => {
+    resetNodeIdCounter();
+  });
+
+  // -------------------------------------------------------------------------
+  // Compile-time type checks (these fail to compile if types are wrong)
+  // -------------------------------------------------------------------------
+
+  test("BoxProps accepts style and event handlers", () => {
+    const props: BoxProps = {
+      style: { width: 10, height: 5, flexDirection: "row", backgroundColor: "#ff0000" },
+      onClick: (_e: KittyMouseEvent) => {},
+      onKeyDown: (_e: KittyKeyboardEvent) => {},
+      onFocus: (_e: KittyFocusEvent) => {},
+      tabIndex: 0,
+      autoFocus: true,
+    };
+    expect(props.style?.width).toBe(10);
+    expect(props.tabIndex).toBe(0);
+    expect(props.autoFocus).toBe(true);
+    expect(typeof props.onClick).toBe("function");
+    expect(typeof props.onKeyDown).toBe("function");
+    expect(typeof props.onFocus).toBe("function");
+  });
+
+  test("TextProps accepts style and string children", () => {
+    const props: TextProps = {
+      style: { color: "red", fontWeight: "bold", fontStyle: "italic", textDecoration: "underline" },
+      children: "Hello, KittyUI!",
+    };
+    expect(props.children).toBe("Hello, KittyUI!");
+    expect(props.style?.fontWeight).toBe("bold");
+  });
+
+  test("ImageProps requires src", () => {
+    const props: ImageProps = {
+      src: "/path/to/image.png",
+      width: 40,
+      height: 20,
+      style: { margin: 1 },
+    };
+    expect(props.src).toBe("/path/to/image.png");
+    expect(props.width).toBe(40);
+    expect(props.height).toBe(20);
+  });
+
+  test("BoxProps accepts all mouse event handlers", () => {
+    const handlers: BoxProps = {
+      onClick: () => {},
+      onMouseEnter: () => {},
+      onMouseLeave: () => {},
+      onMouseDown: () => {},
+      onMouseUp: () => {},
+      onMouseMove: () => {},
+      onScroll: (_e: KittyScrollEvent) => {},
+    };
+    expect(typeof handlers.onClick).toBe("function");
+    expect(typeof handlers.onScroll).toBe("function");
+  });
+
+  test("BoxProps accepts all keyboard event handlers", () => {
+    const handlers: BoxProps = {
+      onKeyDown: () => {},
+      onKeyUp: () => {},
+      onKeyPress: () => {},
+    };
+    expect(typeof handlers.onKeyDown).toBe("function");
+    expect(typeof handlers.onKeyUp).toBe("function");
+    expect(typeof handlers.onKeyPress).toBe("function");
+  });
+
+  test("BoxProps accepts focus/blur handlers", () => {
+    const handlers: BoxProps = {
+      onFocus: () => {},
+      onBlur: () => {},
+    };
+    expect(typeof handlers.onFocus).toBe("function");
+    expect(typeof handlers.onBlur).toBe("function");
+  });
+
+  // -------------------------------------------------------------------------
+  // Runtime prop handling
+  // -------------------------------------------------------------------------
+
+  test("BoxRenderable.applyProps stores event handlers", () => {
+    const box = new BoxRenderable();
+    const onClick = (): void => {};
+    const onKeyDown = (): void => {};
+
+    box.applyProps({
+      style: { width: 20 },
+      onClick,
+      onKeyDown,
+      tabIndex: 1,
+      autoFocus: true,
+    });
+
+    expect(box.eventHandlers.onClick).toBe(onClick);
+    expect(box.eventHandlers.onKeyDown).toBe(onKeyDown);
+    expect(box.tabIndex).toBe(1);
+    expect(box.autoFocus).toBe(true);
+  });
+
+  test("BoxRenderable.applyProps clears removed handlers", () => {
+    const box = new BoxRenderable();
+    const onClick = (): void => {};
+
+    box.applyProps({ onClick });
+    expect(box.eventHandlers.onClick).toBe(onClick);
+
+    box.applyProps({});
+    expect(box.eventHandlers.onClick).toBeUndefined();
+  });
+
+  test("TextRenderable.applyProps applies style", () => {
+    const text = new TextRenderable();
+    text.applyProps({ style: { color: "#00ff00" } });
+    // The style was applied — textStyle should have fg set
+    expect(text.textStyle.fg).toEqual({ type: "rgb", r: 0, g: 255, b: 0 });
+  });
+
+  test("ImageRenderable.applyProps stores src and dimensions", () => {
+    const img = new ImageRenderable();
+    img.applyProps({
+      src: "/path/to/cat.png",
+      width: 80,
+      height: 24,
+      style: { margin: 2 },
+    });
+
+    expect(img.src).toBe("/path/to/cat.png");
+    expect(img.displayWidth).toBe(80);
+    expect(img.displayHeight).toBe(24);
+    // Style was applied
+    expect(img.nodeStyle.margin).toBeDefined();
+  });
+
+  test("createRenderableForType creates ImageRenderable", () => {
+    const instance = createRenderableForType("image");
+    expect(instance).toBeInstanceOf(ImageRenderable);
+    expect(instance.type).toBe("image");
+  });
+
+  test("createRenderableForType throws for unknown type", () => {
+    expect(() => createRenderableForType("canvas")).toThrow('Unknown KittyUI element type: "canvas"');
+  });
+
+  // -------------------------------------------------------------------------
+  // Style type coverage
+  // -------------------------------------------------------------------------
+
+  test("CSSStyle supports full flexbox properties via BoxProps", () => {
+    const props: BoxProps = {
+      style: {
+        width: 100,
+        height: 50,
+        minWidth: 10,
+        minHeight: 5,
+        maxWidth: 200,
+        maxHeight: 100,
+        flexDirection: "column",
+        flexGrow: 1,
+        flexShrink: 0,
+        flexBasis: "auto",
+        flexWrap: "wrap",
+        justifyContent: "space-between",
+        alignItems: "center",
+        padding: [1, 2, 3, 4],
+        margin: 1,
+        gap: [1, 2],
+        backgroundColor: "#333",
+        color: "#fff",
+        fontWeight: "bold",
+        fontStyle: "italic",
+        textDecoration: "underline",
+      },
+    };
+    expect(props.style?.flexDirection).toBe("column");
+    expect(props.style?.justifyContent).toBe("space-between");
+  });
+
+  test("Ref types are accepted on BoxProps", () => {
+    let captured: BoxRenderable | null = null;
+    const props: BoxProps = {
+      ref: (instance) => {
+        captured = instance;
+      },
+    };
+    // Call the ref callback to verify the type works
+    if (typeof props.ref === "function") {
+      props.ref(new BoxRenderable());
+    }
+    expect(captured).toBeInstanceOf(BoxRenderable);
+  });
+
+  test("Ref object type is accepted on BoxProps", () => {
+    const refObj: { current: BoxRenderable | null } = { current: null };
+    const props: BoxProps = { ref: refObj };
+    expect(props.ref).toBe(refObj);
+  });
+});

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -1,0 +1,116 @@
+/**
+ * JSX intrinsic element types, style props, and event handler props for KittyUI.
+ */
+
+import type { CSSStyle, KeyEvent, MouseEvent as CoreMouseEvent } from "@kittyui/core";
+import type { BoxRenderable, TextRenderable } from "./renderables.js";
+
+// ---------------------------------------------------------------------------
+// Event handler types
+// ---------------------------------------------------------------------------
+
+/** Mouse event delivered to a KittyUI element. */
+export interface KittyMouseEvent {
+  /** X coordinate relative to the element. */
+  x: number;
+  /** Y coordinate relative to the element. */
+  y: number;
+  /** The underlying core mouse event. */
+  nativeEvent: CoreMouseEvent;
+}
+
+/** Keyboard event delivered to a KittyUI element. */
+export interface KittyKeyboardEvent {
+  /** The underlying core key event. */
+  nativeEvent: KeyEvent;
+}
+
+/** Focus/blur event delivered to a KittyUI element. */
+export interface KittyFocusEvent {
+  /** The node ID that gained or lost focus. */
+  nodeId: number;
+}
+
+/** Scroll event delivered to a KittyUI element. */
+export interface KittyScrollEvent {
+  /** Scroll delta X. */
+  deltaX: number;
+  /** Scroll delta Y. */
+  deltaY: number;
+}
+
+// ---------------------------------------------------------------------------
+// Event handler props
+// ---------------------------------------------------------------------------
+
+export interface MouseEventHandlers {
+  onClick?: (event: KittyMouseEvent) => void;
+  onMouseEnter?: (event: KittyMouseEvent) => void;
+  onMouseLeave?: (event: KittyMouseEvent) => void;
+  onMouseDown?: (event: KittyMouseEvent) => void;
+  onMouseUp?: (event: KittyMouseEvent) => void;
+  onMouseMove?: (event: KittyMouseEvent) => void;
+  onScroll?: (event: KittyScrollEvent) => void;
+}
+
+export interface KeyboardEventHandlers {
+  onKeyDown?: (event: KittyKeyboardEvent) => void;
+  onKeyUp?: (event: KittyKeyboardEvent) => void;
+  onKeyPress?: (event: KittyKeyboardEvent) => void;
+}
+
+export interface FocusEventHandlers {
+  onFocus?: (event: KittyFocusEvent) => void;
+  onBlur?: (event: KittyFocusEvent) => void;
+}
+
+// ---------------------------------------------------------------------------
+// Focus props
+// ---------------------------------------------------------------------------
+
+export interface FocusProps {
+  /** Tab order for keyboard navigation. */
+  tabIndex?: number;
+  /** Whether to auto-focus this element on mount. */
+  autoFocus?: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Ref support
+// ---------------------------------------------------------------------------
+
+/** Callback ref or React ref object. */
+export type KittyRef<T> =
+  | ((instance: T | null) => void)
+  | { current: T | null };
+
+// ---------------------------------------------------------------------------
+// Component props
+// ---------------------------------------------------------------------------
+
+export interface BoxProps
+  extends MouseEventHandlers,
+    KeyboardEventHandlers,
+    FocusEventHandlers,
+    FocusProps {
+  style?: CSSStyle;
+  children?: React.ReactNode;
+  key?: React.Key;
+  ref?: KittyRef<BoxRenderable>;
+}
+
+export interface TextProps {
+  style?: CSSStyle;
+  children?: string;
+  key?: React.Key;
+  ref?: KittyRef<TextRenderable>;
+}
+
+export interface ImageProps extends FocusProps {
+  src: string;
+  width?: number;
+  height?: number;
+  style?: CSSStyle;
+  key?: React.Key;
+  ref?: KittyRef<BoxRenderable>;
+}


### PR DESCRIPTION
## Summary
- Add type-safe JSX intrinsic element declarations for `<box>`, `<text>`, and `<image>` via `jsx.d.ts`
- Define comprehensive prop types: `BoxProps` (style + all event handlers + focus + ref), `TextProps` (style + string children), `ImageProps` (src + dimensions + style)
- Add mouse, keyboard, focus, and scroll event handler types building on core's `KeyEvent` and `MouseEvent`
- Add `ImageRenderable` class and register it in the reconciler host-config
- Include focus props (`tabIndex`, `autoFocus`) and ref support (`KittyRef<T>`)

## Test plan
- [x] Compile-time type checks verify all prop shapes (BoxProps, TextProps, ImageProps)
- [x] Runtime tests verify `applyProps` stores event handlers, focus props, and image src/dimensions
- [x] Tests verify handler cleanup on re-render (removed handlers become undefined)
- [x] Tests verify `createRenderableForType("image")` works and unknown types throw
- [x] Full test suite passes (291 tests, 0 failures)
- [x] TypeScript typecheck passes with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)