### PR TITLE
feat: implement createApp() entry point and application lifecycle

### DIFF
--- a/packages/react/src/app.test.ts
+++ b/packages/react/src/app.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, test } from "bun:test";
+import { nativeAvailable } from "@kittyui/core";
+import { createApp, type AppHandle, type AppOptions } from "./app.js";
+import { TerminalContext, TerminalProvider, type TerminalContextValue } from "./context.js";
+
+// ---------------------------------------------------------------------------
+// Structural / type tests (no native lib required)
+// ---------------------------------------------------------------------------
+
+describe("createApp exports", () => {
+  test("createApp is a function", () => {
+    expect(typeof createApp).toBe("function");
+  });
+
+  test("AppHandle type has unmount and shutdown", () => {
+    // Type-level check — we verify the shape via a type assertion.
+    // At runtime we just confirm the exports exist.
+    const handle: AppHandle = { unmount() {}, shutdown() {} };
+    expect(handle.unmount).toBeFunction();
+    expect(handle.shutdown).toBeFunction();
+  });
+
+  test("AppOptions accepts fps and debug", () => {
+    const opts: AppOptions = { fps: 60, debug: true };
+    expect(opts.fps).toBe(60);
+    expect(opts.debug).toBe(true);
+  });
+
+  test("AppOptions is optional (all fields optional)", () => {
+    const opts: AppOptions = {};
+    expect(opts).toBeDefined();
+  });
+});
+
+describe("TerminalContext exports", () => {
+  test("TerminalContext is defined", () => {
+    expect(TerminalContext).toBeDefined();
+  });
+
+  test("TerminalProvider is a function", () => {
+    expect(typeof TerminalProvider).toBe("function");
+  });
+
+  test("TerminalContextValue shape", () => {
+    const value: TerminalContextValue = {
+      cols: 80,
+      rows: 24,
+      bridge: {} as TerminalContextValue["bridge"],
+    };
+    expect(value.cols).toBe(80);
+    expect(value.rows).toBe(24);
+    expect(value.bridge).toBeDefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Integration tests (require native lib)
+// ---------------------------------------------------------------------------
+
+describe.skipIf(!nativeAvailable)("createApp integration", () => {
+  test("createApp returns handle with unmount and shutdown", () => {
+    const React = require("react");
+    const element = React.createElement("box", { style: { width: 10 } });
+
+    // We need to capture process.exit to prevent the test runner from dying
+    const originalExit = process.exit;
+    let exitCalled = false;
+    process.exit = (() => {
+      exitCalled = true;
+    }) as never;
+
+    try {
+      const handle = createApp(element);
+      expect(handle).toBeDefined();
+      expect(handle.unmount).toBeFunction();
+      expect(handle.shutdown).toBeFunction();
+
+      // Shutdown should not throw
+      handle.shutdown();
+      expect(exitCalled).toBe(true);
+    } finally {
+      process.exit = originalExit;
+    }
+  });
+
+  test("shutdown is idempotent (calling twice does not throw)", () => {
+    const React = require("react");
+    const element = React.createElement("box");
+
+    const originalExit = process.exit;
+    process.exit = (() => {}) as never;
+
+    try {
+      const handle = createApp(element);
+      handle.shutdown();
+      // Second call should be a no-op
+      handle.shutdown();
+    } finally {
+      process.exit = originalExit;
+    }
+  });
+
+  test("createApp accepts custom fps option", () => {
+    const React = require("react");
+    const element = React.createElement("box");
+
+    const originalExit = process.exit;
+    process.exit = (() => {}) as never;
+
+    try {
+      const handle = createApp(element, { fps: 60 });
+      expect(handle).toBeDefined();
+      handle.shutdown();
+    } finally {
+      process.exit = originalExit;
+    }
+  });
+
+  test("createApp accepts debug option", () => {
+    const React = require("react");
+    const element = React.createElement("box");
+
+    const originalExit = process.exit;
+    process.exit = (() => {}) as never;
+
+    try {
+      const handle = createApp(element, { debug: true });
+      expect(handle).toBeDefined();
+      handle.shutdown();
+    } finally {
+      process.exit = originalExit;
+    }
+  });
+});

--- a/packages/react/src/app.ts
+++ b/packages/react/src/app.ts
@@ -1,0 +1,201 @@
+/**
+ * createApp — single-call entry point for KittyUI applications.
+ *
+ * Initialises the Rust engine, wires up the React reconciler, starts the
+ * render loop, and handles stdin/resize/shutdown lifecycle.
+ */
+
+import { createElement, type ReactElement } from "react";
+import { Bridge, MutationEncoder, RenderableTree } from "@kittyui/core";
+import { createRoot } from "./reconciler.js";
+import { TerminalProvider } from "./context.js";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const DEFAULT_FPS = 30;
+const DEFAULT_COLS = 80;
+const DEFAULT_ROWS = 24;
+const MS_PER_SECOND = 1000;
+
+// Key codes used for shutdown detection
+const CTRL_C = "\x03";
+const QUIT_KEY = "q";
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/** Options for `createApp()`. */
+export interface AppOptions {
+  /** Target frames per second for the render loop (default: 30). */
+  fps?: number;
+  /** Enable debug logging (default: false). */
+  debug?: boolean;
+}
+
+/** Handle returned by `createApp()` for programmatic control. */
+export interface AppHandle {
+  /** Unmount the React tree (does not shut down the engine). */
+  unmount(): void;
+  /** Graceful shutdown: stops render loop, restores terminal, unmounts React, exits. */
+  shutdown(): void;
+}
+
+// ---------------------------------------------------------------------------
+// createApp
+// ---------------------------------------------------------------------------
+
+/**
+ * Bootstrap a KittyUI terminal application from a single JSX element.
+ *
+ * ```tsx
+ * import { createApp } from "@kittyui/react";
+ * createApp(<App />);
+ * ```
+ */
+export const createApp = (
+  element: ReactElement,
+  options: AppOptions = {},
+): AppHandle => {
+  const { fps = DEFAULT_FPS, debug = false } = options;
+
+  // -----------------------------------------------------------------------
+  // 1. Initialise Bridge (enters alt screen, hides cursor)
+  // -----------------------------------------------------------------------
+  const bridge = new Bridge();
+  const initResult = bridge.init();
+
+  if (debug) {
+    const { versionMajor, versionMinor, versionPatch } = initResult;
+    // eslint-disable-next-line no-console
+    console.error(
+      `[kittyui] engine v${versionMajor}.${versionMinor}.${versionPatch} initialised`,
+    );
+  }
+
+  // -----------------------------------------------------------------------
+  // 2. Create RenderableTree + MutationEncoder
+  // -----------------------------------------------------------------------
+  const encoder = bridge.getEncoder();
+  const tree = new RenderableTree(encoder);
+
+  // -----------------------------------------------------------------------
+  // 3. Create React root via the reconciler
+  // -----------------------------------------------------------------------
+  const root = createRoot(tree);
+
+  // -----------------------------------------------------------------------
+  // 4. Render the user's element wrapped in TerminalProvider
+  // -----------------------------------------------------------------------
+  const wrappedElement = createElement(
+    TerminalProvider,
+    { bridge },
+    element,
+  );
+  root.render(wrappedElement);
+
+  // -----------------------------------------------------------------------
+  // Track shutdown state
+  // -----------------------------------------------------------------------
+  let isShutdown = false;
+
+  // -----------------------------------------------------------------------
+  // 5. Set up stdin in raw mode for keyboard input
+  // -----------------------------------------------------------------------
+  const stdinDataHandler = (data: string | Buffer): void => {
+    const key = typeof data === "string" ? data : data.toString("utf8");
+
+    // Ctrl+C or 'q' triggers graceful shutdown
+    if (key === CTRL_C || key === QUIT_KEY) {
+      shutdown();
+      return;
+    }
+
+    // Push every byte as a key event (keyCode = char code, no modifiers, type = keyDown=0)
+    for (let i = 0; i < key.length; i++) {
+      bridge.pushKeyEvent(key.charCodeAt(i), 0, 0);
+    }
+  };
+
+  if (process.stdin.isTTY) {
+    process.stdin.setRawMode(true);
+    process.stdin.resume();
+    process.stdin.setEncoding("utf8");
+    process.stdin.on("data", stdinDataHandler);
+  }
+
+  // -----------------------------------------------------------------------
+  // 6. Start render loop
+  // -----------------------------------------------------------------------
+  const FRAME_MS = Math.floor(MS_PER_SECOND / fps);
+  const renderLoop = setInterval(() => {
+    tree.flushDirtyStyles();
+    bridge.flushMutations();
+    bridge.renderFrame();
+  }, FRAME_MS);
+
+  // -----------------------------------------------------------------------
+  // 7. Handle terminal resize
+  // -----------------------------------------------------------------------
+  const resizeHandler = (): void => {
+    bridge.requestRender();
+  };
+  process.stdout.on("resize", resizeHandler);
+
+  // -----------------------------------------------------------------------
+  // 8. Handle SIGTERM / SIGINT
+  // -----------------------------------------------------------------------
+  const signalHandler = (): void => {
+    shutdown();
+  };
+  process.on("SIGTERM", signalHandler);
+  process.on("SIGINT", signalHandler);
+
+  // -----------------------------------------------------------------------
+  // Unmount (just React, not the engine)
+  // -----------------------------------------------------------------------
+  const unmount = (): void => {
+    root.unmount();
+  };
+
+  // -----------------------------------------------------------------------
+  // Graceful shutdown
+  // -----------------------------------------------------------------------
+  const shutdown = (): void => {
+    if (isShutdown) return;
+    isShutdown = true;
+
+    // Stop render loop
+    clearInterval(renderLoop);
+
+    // Restore stdin
+    if (process.stdin.isTTY) {
+      process.stdin.off("data", stdinDataHandler);
+      process.stdin.setRawMode(false);
+      process.stdin.pause();
+    }
+
+    // Remove listeners
+    process.stdout.off("resize", resizeHandler);
+    process.off("SIGTERM", signalHandler);
+    process.off("SIGINT", signalHandler);
+
+    // Unmount React tree
+    root.unmount();
+
+    // Shut down Rust engine (exits alt screen, shows cursor)
+    bridge.shutdown();
+
+    if (debug) {
+      // eslint-disable-next-line no-console
+      console.error("[kittyui] shutdown complete");
+    }
+
+    // Exit process
+    process.exit(0);
+  };
+
+  return { unmount, shutdown };
+};

--- a/packages/react/src/context.ts
+++ b/packages/react/src/context.ts
@@ -1,0 +1,62 @@
+/**
+ * TerminalContext — React context providing terminal dimensions and bridge access.
+ */
+
+import { createContext, createElement, useState, useEffect, type ReactNode } from "react";
+import type { Bridge } from "@kittyui/core";
+
+// ---------------------------------------------------------------------------
+// Context value
+// ---------------------------------------------------------------------------
+
+export interface TerminalContextValue {
+  /** Number of terminal columns. */
+  cols: number;
+  /** Number of terminal rows. */
+  rows: number;
+  /** The KittyUI Bridge instance. */
+  bridge: Bridge;
+}
+
+/**
+ * React context that provides terminal dimensions and the Bridge instance.
+ * Must be consumed within a `<TerminalProvider>`.
+ */
+// eslint-disable-next-line unicorn/no-null -- createContext requires a default value
+export const TerminalContext = createContext<TerminalContextValue | null>(null);
+
+// ---------------------------------------------------------------------------
+// Provider
+// ---------------------------------------------------------------------------
+
+interface TerminalProviderProps {
+  bridge: Bridge;
+  children?: ReactNode;
+}
+
+/**
+ * Provider component that wraps the user's app and exposes terminal dimensions
+ * and the Bridge via React context. Listens for resize events on stdout to
+ * keep `cols` and `rows` up to date.
+ */
+export const TerminalProvider = ({ bridge, children }: TerminalProviderProps): ReactNode => {
+  const [cols, setCols] = useState(process.stdout.columns || 80);
+  const [rows, setRows] = useState(process.stdout.rows || 24);
+
+  useEffect(() => {
+    const onResize = (): void => {
+      setCols(process.stdout.columns || 80);
+      setRows(process.stdout.rows || 24);
+    };
+    process.stdout.on("resize", onResize);
+    return () => {
+      process.stdout.off("resize", onResize);
+    };
+  }, []);
+
+  return createElement(
+    TerminalContext.Provider,
+    { value: { cols, rows, bridge } },
+    children,
+  );
+};

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -5,6 +5,8 @@
 export { hello } from "@kittyui/core";
 export { createRoot, type KittyRoot } from "./reconciler.js";
 export { BoxRenderable, ImageRenderable, TextRenderable, createRenderableForType, type KittyProps } from "./renderables.js";
+export { createApp, type AppHandle, type AppOptions } from "./app.js";
+export { TerminalContext, TerminalProvider, type TerminalContextValue } from "./context.js";
 
 // JSX prop and event types
 export type {


### PR DESCRIPTION
## Summary
- Add `createApp(element, options?)` as the single-call entry point that bootstraps a full KittyUI terminal app: initializes Bridge/Rust engine, creates RenderableTree, wires up React reconciler, starts a 30fps render loop, handles stdin raw mode for keyboard input, and manages graceful shutdown on Ctrl+C/SIGTERM/`q`
- Add `TerminalContext` and `TerminalProvider` for exposing terminal dimensions (`cols`, `rows`) and the `Bridge` instance to child components via React context, with automatic resize tracking
- Export `createApp`, `AppHandle`, `AppOptions`, `TerminalContext`, `TerminalProvider`, and `TerminalContextValue` from `@kittyui/react`

## Test plan
- [x] Structural tests verify exports, types, and shapes without native lib
- [x] Integration tests (skipped when native lib unavailable) verify createApp returns correct handle, shutdown is idempotent, and custom options work
- [x] All existing tests continue to pass (32 pass, 5 skip in react; 261 pass, 43 skip in core)
- [x] TypeScript typecheck passes

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)