### PR TITLE
feat: add EventDispatcher for Rust engine to React handler wiring

### DIFF
--- a/packages/react/src/app.ts
+++ b/packages/react/src/app.ts
@@ -9,6 +9,7 @@ import { createElement, type ReactElement } from "react";
 import { Bridge, MutationEncoder, RenderableTree } from "@kittyui/core";
 import { createRoot } from "./reconciler.js";
 import { TerminalProvider } from "./context.js";
+import { EventDispatcher } from "./event-dispatcher.js";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -82,12 +83,18 @@ export const createApp = (
   const tree = new RenderableTree(encoder);
 
   // -----------------------------------------------------------------------
-  // 3. Create React root via the reconciler
+  // 3. Create EventDispatcher and wire to bridge events
+  // -----------------------------------------------------------------------
+  const dispatcher = new EventDispatcher(bridge, tree);
+  bridge.onEvents((events) => dispatcher.handleEvents(events));
+
+  // -----------------------------------------------------------------------
+  // 4. Create React root via the reconciler
   // -----------------------------------------------------------------------
   const root = createRoot(tree);
 
   // -----------------------------------------------------------------------
-  // 4. Render the user's element wrapped in TerminalProvider
+  // 5. Render the user's element wrapped in TerminalProvider
   // -----------------------------------------------------------------------
   const wrappedElement = createElement(
     TerminalProvider,
@@ -102,7 +109,7 @@ export const createApp = (
   let isShutdown = false;
 
   // -----------------------------------------------------------------------
-  // 5. Set up stdin in raw mode for keyboard input
+  // 6. Set up stdin in raw mode for keyboard input
   // -----------------------------------------------------------------------
   const stdinDataHandler = (data: string | Buffer): void => {
     const key = typeof data === "string" ? data : data.toString("utf8");
@@ -113,9 +120,11 @@ export const createApp = (
       return;
     }
 
-    // Push every byte as a key event (keyCode = char code, no modifiers, type = keyDown=0)
+    // Push every byte as a key event and dispatch through the event dispatcher
     for (let i = 0; i < key.length; i++) {
-      bridge.pushKeyEvent(key.charCodeAt(i), 0, 0);
+      const keyCode = key.charCodeAt(i);
+      bridge.pushKeyEvent(keyCode, 0, 0);
+      dispatcher.handleStdinKeyEvent(keyCode, 0, 0);
     }
   };
 
@@ -127,7 +136,7 @@ export const createApp = (
   }
 
   // -----------------------------------------------------------------------
-  // 6. Start render loop
+  // 7. Start render loop
   // -----------------------------------------------------------------------
   const FRAME_MS = Math.floor(MS_PER_SECOND / fps);
   const renderLoop = setInterval(() => {
@@ -137,7 +146,7 @@ export const createApp = (
   }, FRAME_MS);
 
   // -----------------------------------------------------------------------
-  // 7. Handle terminal resize
+  // 8. Handle terminal resize
   // -----------------------------------------------------------------------
   const resizeHandler = (): void => {
     bridge.requestRender();
@@ -145,7 +154,7 @@ export const createApp = (
   process.stdout.on("resize", resizeHandler);
 
   // -----------------------------------------------------------------------
-  // 8. Handle SIGTERM / SIGINT
+  // 9. Handle SIGTERM / SIGINT
   // -----------------------------------------------------------------------
   const signalHandler = (): void => {
     shutdown();

--- a/packages/react/src/event-dispatcher.test.ts
+++ b/packages/react/src/event-dispatcher.test.ts
@@ -1,0 +1,481 @@
+import { describe, expect, mock, test, beforeEach } from "bun:test";
+import { MutationEncoder, RenderableTree, resetNodeIdCounter } from "@kittyui/core";
+import { EventDispatcher } from "./event-dispatcher.js";
+import { BoxRenderable } from "./renderables.js";
+import type { KittyMouseEvent, KittyKeyboardEvent, KittyFocusEvent } from "./types.js";
+import type { KittyEvent } from "@kittyui/core";
+
+// ---------------------------------------------------------------------------
+// Mock Bridge
+// ---------------------------------------------------------------------------
+
+const createMockBridge = () => ({
+  hitTest: mock((_x: number, _y: number): number[] => []),
+  getFocusedNode: mock((): number | null => null),
+  focus: mock((_id: number) => true),
+  blur: mock(() => true),
+  onEvents: mock((_listener: (events: KittyEvent[]) => void) => {}),
+  pushKeyEvent: mock((_keyCode: number, _modifiers: number, _eventType: number) => {}),
+});
+
+type MockBridge = ReturnType<typeof createMockBridge>;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a simple tree: root -> child -> grandchild.
+ * Returns { tree, root, child, grandchild } with their node IDs.
+ */
+const buildTree = () => {
+  const encoder = new MutationEncoder();
+  const tree = new RenderableTree(encoder);
+
+  const root = new BoxRenderable();
+  const child = new BoxRenderable();
+  const grandchild = new BoxRenderable();
+
+  tree.setRoot(root);
+  tree.appendChild(root.nodeId, child);
+  tree.appendChild(child.nodeId, grandchild);
+
+  return { tree, root, child, grandchild };
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("EventDispatcher", () => {
+  beforeEach(() => {
+    resetNodeIdCounter();
+  });
+
+  // -----------------------------------------------------------------------
+  // Mouse click dispatching
+  // -----------------------------------------------------------------------
+
+  describe("mouse click events", () => {
+    test("dispatches onClick to the correct renderable", () => {
+      const { tree, child } = buildTree();
+      const bridge = createMockBridge();
+
+      // hitTest returns [child.nodeId] (child is the deepest hit)
+      bridge.hitTest.mockImplementation(() => [child.nodeId]);
+
+      const dispatcher = new EventDispatcher(bridge as any, tree);
+      const onClickSpy = mock((_e: KittyMouseEvent) => {});
+      child.eventHandlers.onClick = onClickSpy;
+
+      dispatcher.handleEvents([
+        {
+          type: "mouse",
+          button: 0, // left click
+          x: 5,
+          y: 5,
+          pixelX: 0,
+          pixelY: 0,
+          modifiers: 0,
+          nodeId: child.nodeId,
+        },
+      ]);
+
+      expect(onClickSpy).toHaveBeenCalledTimes(1);
+      const event = onClickSpy.mock.calls[0][0];
+      expect(event.x).toBe(5);
+      expect(event.y).toBe(5);
+    });
+
+    test("event bubbles up to parent when child does not handle it", () => {
+      const { tree, root, child, grandchild } = buildTree();
+      const bridge = createMockBridge();
+
+      // hitTest returns [grandchild, child, root]
+      bridge.hitTest.mockImplementation(() => [
+        grandchild.nodeId,
+        child.nodeId,
+        root.nodeId,
+      ]);
+
+      const dispatcher = new EventDispatcher(bridge as any, tree);
+
+      // Only root has an onClick handler — grandchild and child do not
+      const rootClickSpy = mock((_e: KittyMouseEvent) => {});
+      root.eventHandlers.onClick = rootClickSpy;
+
+      dispatcher.handleEvents([
+        {
+          type: "mouse",
+          button: 0,
+          x: 2,
+          y: 3,
+          pixelX: 0,
+          pixelY: 0,
+          modifiers: 0,
+          nodeId: grandchild.nodeId,
+        },
+      ]);
+
+      expect(rootClickSpy).toHaveBeenCalledTimes(1);
+    });
+
+    test("bubbling stops at the first handler", () => {
+      const { tree, root, child, grandchild } = buildTree();
+      const bridge = createMockBridge();
+
+      bridge.hitTest.mockImplementation(() => [
+        grandchild.nodeId,
+        child.nodeId,
+        root.nodeId,
+      ]);
+
+      const dispatcher = new EventDispatcher(bridge as any, tree);
+
+      const childClickSpy = mock((_e: KittyMouseEvent) => {});
+      const rootClickSpy = mock((_e: KittyMouseEvent) => {});
+      child.eventHandlers.onClick = childClickSpy;
+      root.eventHandlers.onClick = rootClickSpy;
+
+      dispatcher.handleEvents([
+        {
+          type: "mouse",
+          button: 0,
+          x: 1,
+          y: 1,
+          pixelX: 0,
+          pixelY: 0,
+          modifiers: 0,
+          nodeId: grandchild.nodeId,
+        },
+      ]);
+
+      expect(childClickSpy).toHaveBeenCalledTimes(1);
+      expect(rootClickSpy).toHaveBeenCalledTimes(0);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Mouse enter / leave
+  // -----------------------------------------------------------------------
+
+  describe("mouse enter/leave events", () => {
+    test("fires onMouseEnter when hover target changes", () => {
+      const { tree, child, grandchild } = buildTree();
+      const bridge = createMockBridge();
+
+      const dispatcher = new EventDispatcher(bridge as any, tree);
+
+      const enterSpy = mock((_e: KittyMouseEvent) => {});
+      child.eventHandlers.onMouseEnter = enterSpy;
+
+      // First move: hover enters child
+      bridge.hitTest.mockImplementation(() => [child.nodeId]);
+      dispatcher.handleEvents([
+        {
+          type: "mouse",
+          button: 35, // move
+          x: 3,
+          y: 3,
+          pixelX: 0,
+          pixelY: 0,
+          modifiers: 0,
+          nodeId: child.nodeId,
+        },
+      ]);
+
+      expect(enterSpy).toHaveBeenCalledTimes(1);
+    });
+
+    test("fires onMouseLeave on old node and onMouseEnter on new node", () => {
+      const { tree, child, grandchild } = buildTree();
+      const bridge = createMockBridge();
+
+      const dispatcher = new EventDispatcher(bridge as any, tree);
+
+      const childLeaveSpy = mock((_e: KittyMouseEvent) => {});
+      const grandchildEnterSpy = mock((_e: KittyMouseEvent) => {});
+      child.eventHandlers.onMouseLeave = childLeaveSpy;
+      grandchild.eventHandlers.onMouseEnter = grandchildEnterSpy;
+
+      // First: hover over child
+      bridge.hitTest.mockImplementation(() => [child.nodeId]);
+      dispatcher.handleEvents([
+        {
+          type: "mouse",
+          button: 35,
+          x: 3,
+          y: 3,
+          pixelX: 0,
+          pixelY: 0,
+          modifiers: 0,
+          nodeId: child.nodeId,
+        },
+      ]);
+
+      // Then: hover moves to grandchild
+      bridge.hitTest.mockImplementation(() => [grandchild.nodeId, child.nodeId]);
+      dispatcher.handleEvents([
+        {
+          type: "mouse",
+          button: 35,
+          x: 4,
+          y: 4,
+          pixelX: 0,
+          pixelY: 0,
+          modifiers: 0,
+          nodeId: grandchild.nodeId,
+        },
+      ]);
+
+      expect(childLeaveSpy).toHaveBeenCalledTimes(1);
+      expect(grandchildEnterSpy).toHaveBeenCalledTimes(1);
+    });
+
+    test("does not fire enter/leave when hover target stays the same", () => {
+      const { tree, child } = buildTree();
+      const bridge = createMockBridge();
+
+      const dispatcher = new EventDispatcher(bridge as any, tree);
+
+      const enterSpy = mock((_e: KittyMouseEvent) => {});
+      child.eventHandlers.onMouseEnter = enterSpy;
+
+      bridge.hitTest.mockImplementation(() => [child.nodeId]);
+
+      // Two moves over the same node
+      const mouseMove = {
+        type: "mouse" as const,
+        button: 35,
+        x: 3,
+        y: 3,
+        pixelX: 0,
+        pixelY: 0,
+        modifiers: 0,
+        nodeId: child.nodeId,
+      };
+
+      dispatcher.handleEvents([mouseMove]);
+      dispatcher.handleEvents([mouseMove]);
+
+      expect(enterSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Keyboard events
+  // -----------------------------------------------------------------------
+
+  describe("keyboard events", () => {
+    test("dispatches onKeyDown to focused node", () => {
+      const { tree, child } = buildTree();
+      const bridge = createMockBridge();
+
+      bridge.getFocusedNode.mockImplementation(() => child.nodeId);
+
+      const dispatcher = new EventDispatcher(bridge as any, tree);
+
+      const keyDownSpy = mock((_e: KittyKeyboardEvent) => {});
+      child.eventHandlers.onKeyDown = keyDownSpy;
+
+      dispatcher.handleEvents([
+        {
+          type: "keyboard",
+          keyCode: 65, // 'A'
+          modifiers: 0,
+          eventType: 0, // keydown
+        },
+      ]);
+
+      expect(keyDownSpy).toHaveBeenCalledTimes(1);
+    });
+
+    test("keyboard event bubbles up to parent when child does not handle it", () => {
+      const { tree, root, child } = buildTree();
+      const bridge = createMockBridge();
+
+      bridge.getFocusedNode.mockImplementation(() => child.nodeId);
+
+      const dispatcher = new EventDispatcher(bridge as any, tree);
+
+      // Only root has onKeyDown, child does not
+      const rootKeyDownSpy = mock((_e: KittyKeyboardEvent) => {});
+      root.eventHandlers.onKeyDown = rootKeyDownSpy;
+
+      dispatcher.handleEvents([
+        {
+          type: "keyboard",
+          keyCode: 66, // 'B'
+          modifiers: 0,
+          eventType: 0,
+        },
+      ]);
+
+      expect(rootKeyDownSpy).toHaveBeenCalledTimes(1);
+    });
+
+    test("does not dispatch keyboard events when no node is focused", () => {
+      const { tree, root } = buildTree();
+      const bridge = createMockBridge();
+
+      bridge.getFocusedNode.mockImplementation(() => null);
+
+      const dispatcher = new EventDispatcher(bridge as any, tree);
+
+      const keyDownSpy = mock((_e: KittyKeyboardEvent) => {});
+      root.eventHandlers.onKeyDown = keyDownSpy;
+
+      dispatcher.handleEvents([
+        {
+          type: "keyboard",
+          keyCode: 67,
+          modifiers: 0,
+          eventType: 0,
+        },
+      ]);
+
+      expect(keyDownSpy).toHaveBeenCalledTimes(0);
+    });
+
+    test("handleStdinKeyEvent dispatches to focused node", () => {
+      const { tree, child } = buildTree();
+      const bridge = createMockBridge();
+
+      bridge.getFocusedNode.mockImplementation(() => child.nodeId);
+
+      const dispatcher = new EventDispatcher(bridge as any, tree);
+
+      const keyDownSpy = mock((_e: KittyKeyboardEvent) => {});
+      child.eventHandlers.onKeyDown = keyDownSpy;
+
+      dispatcher.handleStdinKeyEvent(97, 0, 0); // 'a', no modifiers, keydown
+
+      expect(keyDownSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Focus events
+  // -----------------------------------------------------------------------
+
+  describe("focus events", () => {
+    test("fires onFocus when a node gains focus", () => {
+      const { tree, child } = buildTree();
+      const bridge = createMockBridge();
+
+      const dispatcher = new EventDispatcher(bridge as any, tree);
+
+      const focusSpy = mock((_e: KittyFocusEvent) => {});
+      child.eventHandlers.onFocus = focusSpy;
+
+      dispatcher.handleEvents([
+        { type: "focus", nodeId: child.nodeId },
+      ]);
+
+      expect(focusSpy).toHaveBeenCalledTimes(1);
+      expect(focusSpy.mock.calls[0][0].nodeId).toBe(child.nodeId);
+    });
+
+    test("fires onBlur when a node loses focus", () => {
+      const { tree, child } = buildTree();
+      const bridge = createMockBridge();
+
+      const dispatcher = new EventDispatcher(bridge as any, tree);
+
+      const blurSpy = mock((_e: KittyFocusEvent) => {});
+      child.eventHandlers.onBlur = blurSpy;
+
+      dispatcher.handleEvents([
+        { type: "blur", nodeId: child.nodeId },
+      ]);
+
+      expect(blurSpy).toHaveBeenCalledTimes(1);
+      expect(blurSpy.mock.calls[0][0].nodeId).toBe(child.nodeId);
+    });
+
+    test("fires onBlur on old node and onFocus on new node when focus changes", () => {
+      const { tree, child, grandchild } = buildTree();
+      const bridge = createMockBridge();
+
+      const dispatcher = new EventDispatcher(bridge as any, tree);
+
+      const childBlurSpy = mock((_e: KittyFocusEvent) => {});
+      const grandchildFocusSpy = mock((_e: KittyFocusEvent) => {});
+      child.eventHandlers.onBlur = childBlurSpy;
+      grandchild.eventHandlers.onFocus = grandchildFocusSpy;
+
+      // First: child gains focus
+      dispatcher.handleEvents([
+        { type: "focus", nodeId: child.nodeId },
+      ]);
+
+      // Then: grandchild gains focus (should blur child first)
+      dispatcher.handleEvents([
+        { type: "focus", nodeId: grandchild.nodeId },
+      ]);
+
+      expect(childBlurSpy).toHaveBeenCalledTimes(1);
+      expect(grandchildFocusSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // mouseDown / mouseUp
+  // -----------------------------------------------------------------------
+
+  describe("mouseDown / mouseUp events", () => {
+    test("dispatches onMouseDown on left button press", () => {
+      const { tree, child } = buildTree();
+      const bridge = createMockBridge();
+
+      bridge.hitTest.mockImplementation(() => [child.nodeId]);
+
+      const dispatcher = new EventDispatcher(bridge as any, tree);
+
+      const mouseDownSpy = mock((_e: KittyMouseEvent) => {});
+      child.eventHandlers.onMouseDown = mouseDownSpy;
+
+      dispatcher.handleEvents([
+        {
+          type: "mouse",
+          button: 0, // left
+          x: 1,
+          y: 1,
+          pixelX: 0,
+          pixelY: 0,
+          modifiers: 0,
+          nodeId: child.nodeId,
+        },
+      ]);
+
+      expect(mouseDownSpy).toHaveBeenCalledTimes(1);
+    });
+
+    test("dispatches onMouseUp on button release", () => {
+      const { tree, child } = buildTree();
+      const bridge = createMockBridge();
+
+      bridge.hitTest.mockImplementation(() => [child.nodeId]);
+
+      const dispatcher = new EventDispatcher(bridge as any, tree);
+
+      const mouseUpSpy = mock((_e: KittyMouseEvent) => {});
+      child.eventHandlers.onMouseUp = mouseUpSpy;
+
+      dispatcher.handleEvents([
+        {
+          type: "mouse",
+          button: 3, // release
+          x: 1,
+          y: 1,
+          pixelX: 0,
+          pixelY: 0,
+          modifiers: 0,
+          nodeId: child.nodeId,
+        },
+      ]);
+
+      expect(mouseUpSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/packages/react/src/event-dispatcher.ts
+++ b/packages/react/src/event-dispatcher.ts
@@ -1,0 +1,335 @@
+/**
+ * EventDispatcher — dispatches events from the Rust engine to React component
+ * event handlers (onClick, onFocus, onBlur, onKeyDown, etc.).
+ *
+ * Handles:
+ * - Mouse events (click, mousedown, mouseup, mousemove, mouseenter, mouseleave)
+ * - Keyboard events (keydown, keyup, keypress)
+ * - Focus events (focus, blur)
+ * - Event bubbling up the component tree
+ */
+
+import type { Bridge, RenderableTree } from "@kittyui/core";
+import type {
+  KittyEvent,
+  MouseEvent as CoreMouseEvent,
+  KeyboardEvent as CoreKeyboardEvent,
+  FfiFocusEvent,
+  FfiBlurEvent,
+} from "@kittyui/core";
+import type { BoxRenderable } from "./renderables.js";
+import type {
+  KittyMouseEvent,
+  KittyKeyboardEvent,
+  KittyFocusEvent,
+} from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Mouse button mapping: core event button byte -> mouse action
+// ---------------------------------------------------------------------------
+
+/** Mouse button byte values from the Rust engine. */
+const MOUSE_BUTTON_LEFT = 0;
+const MOUSE_BUTTON_MIDDLE = 1;
+const MOUSE_BUTTON_RIGHT = 2;
+const MOUSE_BUTTON_RELEASE = 3;
+const MOUSE_BUTTON_MOVE = 35;
+const MOUSE_BUTTON_SCROLL_UP = 64;
+const MOUSE_BUTTON_SCROLL_DOWN = 65;
+
+// Keyboard event type values from pushKeyEvent (third arg)
+const KEY_EVENT_DOWN = 0;
+const KEY_EVENT_UP = 1;
+const KEY_EVENT_PRESS = 2;
+
+// ---------------------------------------------------------------------------
+// EventDispatcher
+// ---------------------------------------------------------------------------
+
+export class EventDispatcher {
+  private bridge: Bridge;
+  private tree: RenderableTree;
+
+  /** The node ID currently under the mouse pointer (for enter/leave tracking). */
+  private hoveredNodeId: number | null = null;
+
+  /** The previously focused node ID (for focus change detection). */
+  private lastFocusedNodeId: number | null = null;
+
+  constructor(bridge: Bridge, tree: RenderableTree) {
+    this.bridge = bridge;
+    this.tree = tree;
+  }
+
+  // -----------------------------------------------------------------------
+  // Public API
+  // -----------------------------------------------------------------------
+
+  /**
+   * Handle a batch of events from the Rust engine.
+   * Register this with `bridge.onEvents()`.
+   */
+  handleEvents(events: KittyEvent[]): void {
+    for (const event of events) {
+      switch (event.type) {
+        case "mouse":
+          this.handleMouseEvent(event);
+          break;
+        case "keyboard":
+          this.handleKeyboardEvent(event);
+          break;
+        case "focus":
+          this.handleFocusEvent(event);
+          break;
+        case "blur":
+          this.handleBlurEvent(event);
+          break;
+        // resize events are not dispatched to components
+      }
+    }
+  }
+
+  /**
+   * Handle a keyboard event from stdin input.
+   * Use this for events pushed via bridge.pushKeyEvent().
+   */
+  handleStdinKeyEvent(keyCode: number, modifiers: number, eventType: number): void {
+    const focusedNodeId = this.bridge.getFocusedNode();
+
+    const kittyEvent: KittyKeyboardEvent = {
+      nativeEvent: {
+        key: { type: "char", char: String.fromCharCode(keyCode) },
+        modifiers: {
+          shift: (modifiers & 1) !== 0,
+          alt: (modifiers & 2) !== 0,
+          ctrl: (modifiers & 4) !== 0,
+          super: (modifiers & 8) !== 0,
+        },
+        eventType: eventType === KEY_EVENT_UP ? "release" : eventType === KEY_EVENT_PRESS ? "press" : "press",
+      },
+    };
+
+    const handlerKey =
+      eventType === KEY_EVENT_UP
+        ? "onKeyUp"
+        : eventType === KEY_EVENT_PRESS
+          ? "onKeyPress"
+          : "onKeyDown";
+
+    if (focusedNodeId !== null) {
+      this.dispatchKeyboardToNode(focusedNodeId, handlerKey, kittyEvent);
+    }
+  }
+
+  // -----------------------------------------------------------------------
+  // Mouse event handling
+  // -----------------------------------------------------------------------
+
+  private handleMouseEvent(event: CoreMouseEvent): void {
+    const { x, y, button, modifiers, nodeId } = event;
+
+    // Build the hit path: use hitTest for the full ancestor chain
+    const hitPath = this.bridge.hitTest(x, y);
+
+    // If hitPath is empty and nodeId is provided, use nodeId as fallback
+    const targetNodeId = hitPath.length > 0 ? hitPath[0] : (nodeId !== 0xffffffff ? nodeId : null);
+
+    const nativeEvent: CoreMouseEvent = event;
+
+    const kittyEvent: KittyMouseEvent = {
+      x,
+      y,
+      nativeEvent,
+    };
+
+    // Track enter/leave
+    this.updateHoverState(targetNodeId, kittyEvent);
+
+    // Determine which handler to call based on button
+    if (button === MOUSE_BUTTON_LEFT) {
+      // Left click (press)
+      this.dispatchMouseAlongPath(hitPath, "onMouseDown", kittyEvent);
+      this.dispatchMouseAlongPath(hitPath, "onClick", kittyEvent);
+    } else if (button === MOUSE_BUTTON_RELEASE) {
+      this.dispatchMouseAlongPath(hitPath, "onMouseUp", kittyEvent);
+    } else if (button === MOUSE_BUTTON_MOVE) {
+      this.dispatchMouseAlongPath(hitPath, "onMouseMove", kittyEvent);
+    } else if (button === MOUSE_BUTTON_MIDDLE || button === MOUSE_BUTTON_RIGHT) {
+      this.dispatchMouseAlongPath(hitPath, "onMouseDown", kittyEvent);
+    } else if (button === MOUSE_BUTTON_SCROLL_UP || button === MOUSE_BUTTON_SCROLL_DOWN) {
+      const deltaY = button === MOUSE_BUTTON_SCROLL_UP ? -1 : 1;
+      this.dispatchScrollAlongPath(hitPath, deltaY);
+    }
+  }
+
+  /**
+   * Dispatch a mouse event along the hit path (bubbling).
+   * Tries the deepest node first; if it doesn't handle it, walks up.
+   */
+  private dispatchMouseAlongPath(
+    hitPath: number[],
+    handlerKey: "onClick" | "onMouseDown" | "onMouseUp" | "onMouseMove",
+    event: KittyMouseEvent,
+  ): void {
+    for (const nodeId of hitPath) {
+      const renderable = this.tree.get(nodeId);
+      if (!renderable) continue;
+
+      const handler = (renderable as BoxRenderable).eventHandlers?.[handlerKey];
+      if (handler) {
+        handler(event);
+        return; // Event handled, stop bubbling
+      }
+    }
+  }
+
+  /**
+   * Dispatch scroll events along the hit path (bubbling).
+   */
+  private dispatchScrollAlongPath(hitPath: number[], deltaY: number): void {
+    for (const nodeId of hitPath) {
+      const renderable = this.tree.get(nodeId);
+      if (!renderable) continue;
+
+      const handler = (renderable as BoxRenderable).eventHandlers?.onScroll;
+      if (handler) {
+        handler({ deltaX: 0, deltaY });
+        return;
+      }
+    }
+  }
+
+  /**
+   * Track mouse enter/leave by comparing the current hover target
+   * with the previous one.
+   */
+  private updateHoverState(
+    currentNodeId: number | null,
+    event: KittyMouseEvent,
+  ): void {
+    if (currentNodeId === this.hoveredNodeId) return;
+
+    // Fire onMouseLeave on the old node
+    if (this.hoveredNodeId !== null) {
+      const oldRenderable = this.tree.get(this.hoveredNodeId);
+      if (oldRenderable) {
+        const leaveHandler = (oldRenderable as BoxRenderable).eventHandlers?.onMouseLeave;
+        if (leaveHandler) {
+          leaveHandler(event);
+        }
+      }
+    }
+
+    // Fire onMouseEnter on the new node
+    if (currentNodeId !== null) {
+      const newRenderable = this.tree.get(currentNodeId);
+      if (newRenderable) {
+        const enterHandler = (newRenderable as BoxRenderable).eventHandlers?.onMouseEnter;
+        if (enterHandler) {
+          enterHandler(event);
+        }
+      }
+    }
+
+    this.hoveredNodeId = currentNodeId;
+  }
+
+  // -----------------------------------------------------------------------
+  // Keyboard event handling
+  // -----------------------------------------------------------------------
+
+  private handleKeyboardEvent(event: CoreKeyboardEvent): void {
+    const focusedNodeId = this.bridge.getFocusedNode();
+    if (focusedNodeId === null) return;
+
+    const kittyEvent: KittyKeyboardEvent = {
+      nativeEvent: {
+        key: { type: "char", char: String.fromCharCode(event.keyCode) },
+        modifiers: {
+          shift: (event.modifiers & 1) !== 0,
+          alt: (event.modifiers & 2) !== 0,
+          ctrl: (event.modifiers & 4) !== 0,
+          super: (event.modifiers & 8) !== 0,
+        },
+        eventType:
+          event.eventType === KEY_EVENT_UP
+            ? "release"
+            : event.eventType === KEY_EVENT_PRESS
+              ? "press"
+              : "press",
+      },
+    };
+
+    const handlerKey =
+      event.eventType === KEY_EVENT_UP
+        ? "onKeyUp"
+        : event.eventType === KEY_EVENT_PRESS
+          ? "onKeyPress"
+          : "onKeyDown";
+
+    this.dispatchKeyboardToNode(focusedNodeId, handlerKey, kittyEvent);
+  }
+
+  /**
+   * Dispatch a keyboard event to a node, bubbling up to ancestors.
+   */
+  private dispatchKeyboardToNode(
+    nodeId: number,
+    handlerKey: "onKeyDown" | "onKeyUp" | "onKeyPress",
+    event: KittyKeyboardEvent,
+  ): void {
+    let currentId: number | null = nodeId;
+
+    while (currentId !== null) {
+      const renderable = this.tree.get(currentId);
+      if (!renderable) break;
+
+      const handler = (renderable as BoxRenderable).eventHandlers?.[handlerKey];
+      if (handler) {
+        handler(event);
+        return; // Event handled, stop bubbling
+      }
+
+      // Walk up to parent
+      const parent = this.tree.parent(currentId);
+      currentId = parent ? parent.nodeId : null;
+    }
+  }
+
+  // -----------------------------------------------------------------------
+  // Focus event handling
+  // -----------------------------------------------------------------------
+
+  private handleFocusEvent(event: FfiFocusEvent): void {
+    // If there was a previously focused node, fire onBlur
+    if (this.lastFocusedNodeId !== null && this.lastFocusedNodeId !== event.nodeId) {
+      this.fireFocusHandler(this.lastFocusedNodeId, "onBlur");
+    }
+
+    // Fire onFocus on the newly focused node
+    this.fireFocusHandler(event.nodeId, "onFocus");
+    this.lastFocusedNodeId = event.nodeId;
+  }
+
+  private handleBlurEvent(event: FfiBlurEvent): void {
+    this.fireFocusHandler(event.nodeId, "onBlur");
+
+    if (this.lastFocusedNodeId === event.nodeId) {
+      this.lastFocusedNodeId = null;
+    }
+  }
+
+  private fireFocusHandler(
+    nodeId: number,
+    handlerKey: "onFocus" | "onBlur",
+  ): void {
+    const renderable = this.tree.get(nodeId);
+    if (!renderable) return;
+
+    const focusEvent: KittyFocusEvent = { nodeId };
+    const handler = (renderable as BoxRenderable).eventHandlers?.[handlerKey];
+    if (handler) {
+      handler(focusEvent);
+    }
+  }
+}

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -6,6 +6,7 @@ export { hello } from "@kittyui/core";
 export { createRoot, type KittyRoot } from "./reconciler.js";
 export { BoxRenderable, ImageRenderable, TextRenderable, createRenderableForType, type KittyProps } from "./renderables.js";
 export { createApp, type AppHandle, type AppOptions } from "./app.js";
+export { EventDispatcher } from "./event-dispatcher.js";
 export { TerminalContext, TerminalProvider, type TerminalContextValue } from "./context.js";
 
 // JSX prop and event types


### PR DESCRIPTION
## Summary
- Add `EventDispatcher` class that dispatches mouse, keyboard, and focus events from the Rust engine bridge to React component event handlers (`onClick`, `onKeyDown`, `onFocus`, `onBlur`, `onMouseEnter`, `onMouseLeave`, etc.)
- Wire the dispatcher into `createApp()` via `bridge.onEvents()` and stdin key handling
- Support event bubbling up the component tree (deepest node first, stop at first handler)
- Track mouse hover state for enter/leave events and focus state for blur-on-change

## What it does
Renderables already store event handlers via `applyProps()`, but nothing was calling them. This PR closes the loop: when the Rust engine produces events (mouse clicks, key presses, focus changes), the `EventDispatcher` looks up the target node in the `RenderableTree`, finds its handler, and invokes it with a typed event object.

## Key design decisions
- **Bubbling**: mouse events use the `bridge.hitTest()` path (deepest to root); keyboard events walk `tree.parent()` from the focused node
- **Enter/leave**: tracked by comparing the deepest hit node across mouse move events
- **Focus change**: the dispatcher tracks the last focused node ID and fires `onBlur`/`onFocus` when it changes via focus/blur engine events
- **Stdin integration**: `handleStdinKeyEvent()` dispatches stdin keyboard input through the same path as engine events

## Test plan
- [x] Mouse click dispatches onClick to correct renderable
- [x] Event bubbles up to parent when child has no handler
- [x] Bubbling stops at the first handler found
- [x] Mouse enter/leave fires when hover target changes
- [x] No spurious enter/leave when hovering the same node
- [x] Keyboard events dispatch to focused node
- [x] Keyboard events bubble up through parents
- [x] No dispatch when no node is focused
- [x] stdin key events dispatch through the dispatcher
- [x] Focus/blur events fire on the correct nodes
- [x] Focus change fires onBlur on old + onFocus on new
- [x] `bun run typecheck` passes
- [x] `bun test` passes (47 pass, 5 skip, 0 fail)

🤖 Generated with [Claude Code](https://claude.com/claude-code)