### PR TITLE
feat: add set_viewport_size FFI for fullscreen rendering

### DIFF
--- a/packages/core-rust/src/ffi_bridge.rs
+++ b/packages/core-rust/src/ffi_bridge.rs
@@ -228,6 +228,17 @@ pub extern "C" fn shutdown() {
     let _ = crate::screen::exit();
 }
 
+/// Set the viewport (available terminal) size.  The next `render_frame()`
+/// call will use these dimensions for layout computation and will resize
+/// the internal cell buffers accordingly.
+#[no_mangle]
+pub extern "C" fn set_viewport_size(cols: u16, rows: u16) {
+    with_engine(|state| {
+        state.cols = f32::from(cols);
+        state.rows = f32::from(rows);
+    });
+}
+
 // ---------------------------------------------------------------------------
 // Test-mode lifecycle (no terminal side effects)
 // ---------------------------------------------------------------------------

--- a/packages/core/src/bridge.ts
+++ b/packages/core/src/bridge.ts
@@ -49,6 +49,7 @@ const symbols = {
   set_focusable: { args: [FFIType.u32, FFIType.u8], returns: FFIType.void },
   set_tab_index: { args: [FFIType.u32, FFIType.i32], returns: FFIType.void },
   set_focus_trap: { args: [FFIType.u32, FFIType.u8], returns: FFIType.void },
+  set_viewport_size: { args: [FFIType.u16, FFIType.u16], returns: FFIType.void },
 } as const;
 
 // -----------------------------------------------------------------------
@@ -270,6 +271,12 @@ export class Bridge {
   setFocusTrap(nodeId: number, enable: boolean): void {
     this.assertReady();
     this.lib!.symbols.set_focus_trap(nodeId, enable ? 1 : 0);
+  }
+
+  /** Set the viewport (terminal) size for layout computation. */
+  setViewportSize(cols: number, rows: number): void {
+    this.assertReady();
+    this.lib!.symbols.set_viewport_size(cols, rows);
   }
 
   /** Decode a raw event buffer and dispatch to listeners. */

--- a/packages/react/src/app.ts
+++ b/packages/react/src/app.ts
@@ -81,6 +81,11 @@ export const createApp = (
   const bridge = new Bridge();
   const initResult = bridge.init();
 
+  // Set viewport to actual terminal size
+  const termCols = process.stdout.columns || DEFAULT_COLS;
+  const termRows = process.stdout.rows || DEFAULT_ROWS;
+  bridge.setViewportSize(termCols, termRows);
+
   if (debug) {
     const { versionMajor, versionMinor, versionPatch } = initResult;
     // eslint-disable-next-line no-console
@@ -161,6 +166,9 @@ export const createApp = (
   // 8. Handle terminal resize
   // -----------------------------------------------------------------------
   const resizeHandler = (): void => {
+    const newCols = process.stdout.columns || DEFAULT_COLS;
+    const newRows = process.stdout.rows || DEFAULT_ROWS;
+    bridge.setViewportSize(newCols, newRows);
     bridge.requestRender();
   };
   process.stdout.on("resize", resizeHandler);


### PR DESCRIPTION
## Summary
- Add `set_viewport_size(cols, rows)` FFI function to set the Rust engine's viewport dimensions
- Call it in `createApp` after init with actual terminal size
- Update resize handler to call `setViewportSize` on terminal resize

Without this, the engine defaults to 80x24 regardless of actual terminal size, causing apps to render in a small area.

## Test plan
- [x] `cargo test` passes (810 tests)
- [x] `cargo clippy -- -D warnings` clean
- [ ] Run dashboard POC — should fill terminal

🤖 Generated with [Claude Code](https://claude.com/claude-code)