### PR TITLE
fix: declare JSX elements on React.JSX namespace for react-jsx transform

### DIFF
--- a/packages/react/src/jsx.d.ts
+++ b/packages/react/src/jsx.d.ts
@@ -1,13 +1,26 @@
 /**
  * JSX intrinsic element declarations for KittyUI.
  *
- * Augments the global JSX namespace so that <box>, <text>, and <image>
- * elements are type-checked in TSX files.
+ * Augments both the global JSX namespace (for classic JSX transform) and
+ * the React.JSX namespace (for react-jsx transform) so that <box>, <text>,
+ * and <image> elements are type-checked in TSX files automatically when
+ * @kittyui/react is imported.
  */
 
 import type { BoxProps, ImageProps, TextProps } from "./types.js";
 
 declare global {
+  // eslint-disable-next-line @typescript-eslint/no-namespace
+  namespace JSX {
+    interface IntrinsicElements {
+      box: BoxProps;
+      text: TextProps;
+      image: ImageProps;
+    }
+  }
+}
+
+declare module "react" {
   // eslint-disable-next-line @typescript-eslint/no-namespace
   namespace JSX {
     interface IntrinsicElements {


### PR DESCRIPTION
## Summary
The `jsx.d.ts` in @kittyui/react only declared on `global JSX`. Users with `jsx: "react-jsx"` in tsconfig got `Property 'box' does not exist on type 'JSX.IntrinsicElements'` and had to create a custom d.ts workaround.

Now declares on both `global JSX` and `React.JSX` so importing the package is sufficient.

🤖 Generated with [Claude Code](https://claude.com/claude-code)