### PR TITLE
fix: re-export jsx.d.ts from @kittyui/react index

### DIFF
--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -2,6 +2,10 @@
  * @kittyui/react — React bindings for KittyUI terminal rendering.
  */
 
+// Re-export JSX type augmentation so importing @kittyui/react registers
+// <box>, <text>, <image> as intrinsic elements automatically.
+export type {} from "./jsx.js";
+
 export { hello } from "@kittyui/core";
 export { createRoot, type KittyRoot } from "./reconciler.js";
 export { BoxRenderable, ImageRenderable, TextRenderable, createRenderableForType, type KittyProps } from "./renderables.js";


### PR DESCRIPTION
## Summary
The `jsx.d.ts` module augmentation wasn't referenced from `index.ts`, so TypeScript never picked up the `<box>`, `<text>`, `<image>` intrinsic element types when consuming code imported from `@kittyui/react`.

Add `export type {} from "./jsx.js"` to make the augmentation visible automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)