### PR TITLE
feat: hover and active states via mouse tracking

### DIFF
--- a/packages/react/src/app.test.ts
+++ b/packages/react/src/app.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { nativeAvailable } from "@kittyui/core";
-import { createApp, type AppHandle, type AppOptions } from "./app.js";
+import { createApp, parseSgrMouse, type AppHandle, type AppOptions } from "./app.js";
 import { TerminalContext, TerminalProvider, type TerminalContextValue } from "./context.js";
 
 // ---------------------------------------------------------------------------
@@ -29,6 +29,67 @@ describe("createApp exports", () => {
   test("AppOptions is optional (all fields optional)", () => {
     const opts: AppOptions = {};
     expect(opts).toBeDefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// SGR mouse sequence parser
+// ---------------------------------------------------------------------------
+
+describe("parseSgrMouse", () => {
+  test("parses left button press", () => {
+    const result = parseSgrMouse("[<0;10;20M");
+    expect(result).not.toBeNull();
+    expect(result!.button).toBe(0);
+    expect(result!.col).toBe(9);  // 10 - 1 (1-based to 0-based)
+    expect(result!.row).toBe(19); // 20 - 1
+    expect(result!.isRelease).toBe(false);
+  });
+
+  test("parses button release (lowercase m)", () => {
+    const result = parseSgrMouse("[<0;5;8m");
+    expect(result).not.toBeNull();
+    expect(result!.button).toBe(0);
+    expect(result!.col).toBe(4);
+    expect(result!.row).toBe(7);
+    expect(result!.isRelease).toBe(true);
+  });
+
+  test("parses mouse move (button 35)", () => {
+    const result = parseSgrMouse("[<35;50;30M");
+    expect(result).not.toBeNull();
+    expect(result!.button).toBe(35);
+    expect(result!.col).toBe(49);
+    expect(result!.row).toBe(29);
+    expect(result!.isRelease).toBe(false);
+  });
+
+  test("parses scroll up (button 64)", () => {
+    const result = parseSgrMouse("[<64;1;1M");
+    expect(result).not.toBeNull();
+    expect(result!.button).toBe(64);
+    expect(result!.col).toBe(0);
+    expect(result!.row).toBe(0);
+  });
+
+  test("parses scroll down (button 65)", () => {
+    const result = parseSgrMouse("[<65;1;1M");
+    expect(result).not.toBeNull();
+    expect(result!.button).toBe(65);
+  });
+
+  test("returns null for non-mouse sequences", () => {
+    expect(parseSgrMouse("[A")).toBeNull();       // arrow key
+    expect(parseSgrMouse("hello")).toBeNull();         // plain text
+    expect(parseSgrMouse("[<invalid")).toBeNull(); // malformed
+    expect(parseSgrMouse("")).toBeNull();              // empty
+  });
+
+  test("handles large coordinates", () => {
+    const result = parseSgrMouse("[<0;200;100M");
+    expect(result).not.toBeNull();
+    expect(result!.col).toBe(199);
+    expect(result!.row).toBe(99);
   });
 });
 

--- a/packages/react/src/app.ts
+++ b/packages/react/src/app.ts
@@ -24,6 +24,14 @@ const MS_PER_SECOND = 1000;
 const CTRL_C = "\x03";
 const QUIT_KEY = "q";
 
+// Terminal mouse tracking escape sequences (SGR mode)
+const MOUSE_ENABLE = "\x1b[?1000h\x1b[?1006h\x1b[?1003h";
+const MOUSE_DISABLE = "\x1b[?1003l\x1b[?1006l\x1b[?1000l";
+
+// SGR mouse sequence regex
+// oxlint-disable-next-line no-control-regex
+const SGR_MOUSE_RE = /^\x1b\[<(\d+);(\d+);(\d+)([Mm])$/;
+
 // Virtual key codes for special keys
 export const KEY_UP = 0x1001;
 export const KEY_DOWN = 0x1002;
@@ -35,6 +43,34 @@ const ESC_MAP: Record<string, number> = {
   "\x1b[B": KEY_DOWN,
   "\x1b[C": KEY_RIGHT,
   "\x1b[D": KEY_LEFT,
+};
+
+// ---------------------------------------------------------------------------
+// SGR mouse parser (exported for testing)
+// ---------------------------------------------------------------------------
+
+/** Parsed SGR mouse event. */
+export interface SgrMouseEvent {
+  button: number;
+  col: number;
+  row: number;
+  isRelease: boolean;
+}
+
+/**
+ * Parse an SGR mouse escape sequence into its components.
+ * Returns null if the input is not a valid SGR mouse sequence.
+ */
+export const parseSgrMouse = (input: string): SgrMouseEvent | null => {
+  if (!input.startsWith("\x1b[<")) return null;
+  const match = input.match(SGR_MOUSE_RE);
+  if (!match) return null;
+  return {
+    button: parseInt(match[1]),
+    col: parseInt(match[2]) - 1,
+    row: parseInt(match[3]) - 1,
+    isRelease: match[4] === "m",
+  };
 };
 
 // ---------------------------------------------------------------------------
@@ -80,6 +116,9 @@ export const createApp = (
   // -----------------------------------------------------------------------
   const bridge = new Bridge();
   const initResult = bridge.init();
+
+  // Enable mouse tracking (SGR mode with move events)
+  process.stdout.write(MOUSE_ENABLE);
 
   // Set viewport to actual terminal size
   const termCols = process.stdout.columns || DEFAULT_COLS;
@@ -135,6 +174,14 @@ export const createApp = (
     // Ctrl+C or 'q' triggers graceful shutdown
     if (key === CTRL_C || key === QUIT_KEY) {
       shutdown();
+      return;
+    }
+
+    // Detect SGR mouse sequences
+    const mouse = parseSgrMouse(key);
+    if (mouse) {
+      bridge.pushMouseEvent(mouse.button, mouse.col, mouse.row, 0, 0, 0);
+      dispatcher.handleMouseFromStdin(mouse.button, mouse.col, mouse.row, mouse.isRelease);
       return;
     }
 
@@ -205,6 +252,9 @@ export const createApp = (
       process.stdin.setRawMode(false);
       process.stdin.pause();
     }
+
+    // Disable mouse tracking
+    process.stdout.write(MOUSE_DISABLE);
 
     // Remove listeners
     process.stdout.off("resize", resizeHandler);

--- a/packages/react/src/event-dispatcher.test.ts
+++ b/packages/react/src/event-dispatcher.test.ts
@@ -421,6 +421,94 @@ describe("EventDispatcher", () => {
   });
 
   // -----------------------------------------------------------------------
+  // handleMouseFromStdin
+  // -----------------------------------------------------------------------
+
+  describe("handleMouseFromStdin", () => {
+    test("dispatches onClick for left button press", () => {
+      const { tree, child } = buildTree();
+      const bridge = createMockBridge();
+
+      bridge.hitTest.mockImplementation(() => [child.nodeId]);
+
+      const dispatcher = new EventDispatcher(bridge as any, tree);
+      const onClickSpy = mock((_e: KittyMouseEvent) => {});
+      child.eventHandlers.onClick = onClickSpy;
+
+      dispatcher.handleMouseFromStdin(0, 5, 10, false);
+
+      expect(onClickSpy).toHaveBeenCalledTimes(1);
+      expect(onClickSpy.mock.calls[0][0].x).toBe(5);
+      expect(onClickSpy.mock.calls[0][0].y).toBe(10);
+    });
+
+    test("dispatches onMouseUp for release", () => {
+      const { tree, child } = buildTree();
+      const bridge = createMockBridge();
+
+      bridge.hitTest.mockImplementation(() => [child.nodeId]);
+
+      const dispatcher = new EventDispatcher(bridge as any, tree);
+      const mouseUpSpy = mock((_e: KittyMouseEvent) => {});
+      child.eventHandlers.onMouseUp = mouseUpSpy;
+
+      dispatcher.handleMouseFromStdin(0, 3, 4, true); // isRelease = true
+
+      expect(mouseUpSpy).toHaveBeenCalledTimes(1);
+    });
+
+    test("dispatches onMouseMove for button 35", () => {
+      const { tree, child } = buildTree();
+      const bridge = createMockBridge();
+
+      bridge.hitTest.mockImplementation(() => [child.nodeId]);
+
+      const dispatcher = new EventDispatcher(bridge as any, tree);
+      const mouseMoveSpy = mock((_e: KittyMouseEvent) => {});
+      child.eventHandlers.onMouseMove = mouseMoveSpy;
+
+      dispatcher.handleMouseFromStdin(35, 7, 8, false);
+
+      expect(mouseMoveSpy).toHaveBeenCalledTimes(1);
+    });
+
+    test("notifies event listeners for useMouse hook", () => {
+      const { tree } = buildTree();
+      const bridge = createMockBridge();
+
+      bridge.hitTest.mockImplementation(() => []);
+
+      const dispatcher = new EventDispatcher(bridge as any, tree);
+      dispatcher.handleMouseFromStdin(0, 1, 1, false);
+
+      expect(bridge.notifyEventListeners).toHaveBeenCalledTimes(1);
+    });
+
+    test("dispatches to correct node via hitTest", () => {
+      const { tree, root, child, grandchild } = buildTree();
+      const bridge = createMockBridge();
+
+      bridge.hitTest.mockImplementation(() => [
+        grandchild.nodeId,
+        child.nodeId,
+        root.nodeId,
+      ]);
+
+      const dispatcher = new EventDispatcher(bridge as any, tree);
+
+      const grandchildClickSpy = mock((_e: KittyMouseEvent) => {});
+      const rootClickSpy = mock((_e: KittyMouseEvent) => {});
+      grandchild.eventHandlers.onClick = grandchildClickSpy;
+      root.eventHandlers.onClick = rootClickSpy;
+
+      dispatcher.handleMouseFromStdin(0, 2, 3, false);
+
+      expect(grandchildClickSpy).toHaveBeenCalledTimes(1);
+      expect(rootClickSpy).toHaveBeenCalledTimes(0); // bubbling stopped
+    });
+  });
+
+  // -----------------------------------------------------------------------
   // mouseDown / mouseUp
   // -----------------------------------------------------------------------
 

--- a/packages/react/src/event-dispatcher.ts
+++ b/packages/react/src/event-dispatcher.ts
@@ -67,7 +67,7 @@ export class EventDispatcher {
 
   /**
    * Handle a batch of events from the Rust engine.
-   * Register this with `bridge.onEvents()`.
+   * Register this with bridge.onEvents().
    */
   handleEvents(events: KittyEvent[]): void {
     for (const event of events) {
@@ -122,6 +122,55 @@ export class EventDispatcher {
 
     // Also broadcast as a raw KittyEvent so useKeyboard hook listeners fire.
     this.bridge.notifyEventListeners([{ type: "keyboard" as const, keyCode, modifiers, eventType }]);
+  }
+
+  /**
+   * Handle a mouse event parsed from stdin SGR sequences.
+   * Creates a synthetic mouse event and dispatches via hitTest.
+   */
+  handleMouseFromStdin(button: number, col: number, row: number, isRelease: boolean): void {
+    const effectiveButton = isRelease ? MOUSE_BUTTON_RELEASE : button;
+
+    const hitPath = this.bridge.hitTest(col, row);
+    const targetNodeId = hitPath.length > 0 ? hitPath[0] : null;
+
+    const nativeEvent: CoreMouseEvent = {
+      type: "mouse",
+      button: effectiveButton,
+      x: col,
+      y: row,
+      pixelX: 0,
+      pixelY: 0,
+      modifiers: 0,
+      nodeId: targetNodeId ?? 0xffffffff,
+    };
+
+    const kittyEvent: KittyMouseEvent = {
+      x: col,
+      y: row,
+      nativeEvent,
+    };
+
+    // Track enter/leave
+    this.updateHoverState(targetNodeId, kittyEvent);
+
+    // Dispatch based on button
+    if (effectiveButton === MOUSE_BUTTON_LEFT) {
+      this.dispatchMouseAlongPath(hitPath, "onMouseDown", kittyEvent);
+      this.dispatchMouseAlongPath(hitPath, "onClick", kittyEvent);
+    } else if (effectiveButton === MOUSE_BUTTON_RELEASE) {
+      this.dispatchMouseAlongPath(hitPath, "onMouseUp", kittyEvent);
+    } else if (effectiveButton === MOUSE_BUTTON_MOVE) {
+      this.dispatchMouseAlongPath(hitPath, "onMouseMove", kittyEvent);
+    } else if (effectiveButton === MOUSE_BUTTON_MIDDLE || effectiveButton === MOUSE_BUTTON_RIGHT) {
+      this.dispatchMouseAlongPath(hitPath, "onMouseDown", kittyEvent);
+    } else if (effectiveButton === MOUSE_BUTTON_SCROLL_UP || effectiveButton === MOUSE_BUTTON_SCROLL_DOWN) {
+      const deltaY = effectiveButton === MOUSE_BUTTON_SCROLL_UP ? -1 : 1;
+      this.dispatchScrollAlongPath(hitPath, deltaY);
+    }
+
+    // Broadcast to event listeners so useMouse hook fires
+    this.bridge.notifyEventListeners([nativeEvent]);
   }
 
   // -----------------------------------------------------------------------

--- a/packages/react/src/hooks.ts
+++ b/packages/react/src/hooks.ts
@@ -222,11 +222,13 @@ export const useMouse = (
             });
             setIsHovered(true);
 
-            // button > 0 indicates a press (button 0 = no button / move)
-            if (event.button > 0) {
-              setIsPressed(true);
-            } else {
+            // Button 0 = left press, 1 = middle, 2 = right, 3 = release, 35 = move
+            const RELEASE = 3;
+            const MOVE = 35;
+            if (event.button === RELEASE) {
               setIsPressed(false);
+            } else if (event.button !== MOVE) {
+              setIsPressed(true);
             }
           } else {
             if (isOver !== undefined) {

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -5,7 +5,7 @@
 export { hello } from "@kittyui/core";
 export { createRoot, type KittyRoot } from "./reconciler.js";
 export { BoxRenderable, ImageRenderable, TextRenderable, createRenderableForType, type KittyProps } from "./renderables.js";
-export { createApp, KEY_UP, KEY_DOWN, KEY_RIGHT, KEY_LEFT, type AppHandle, type AppOptions } from "./app.js";
+export { createApp, parseSgrMouse, KEY_UP, KEY_DOWN, KEY_RIGHT, KEY_LEFT, type AppHandle, type AppOptions, type SgrMouseEvent } from "./app.js";
 export { EventDispatcher } from "./event-dispatcher.js";
 export { TerminalContext, TerminalProvider, type TerminalContextValue } from "./context.js";
 


### PR DESCRIPTION
## Summary
- Parse SGR mouse escape sequences from terminal stdin input
- Enable/disable mouse tracking (SGR mode 1000/1003/1006) in createApp lifecycle
- Add `handleMouseFromStdin` to EventDispatcher for stdin-sourced mouse events with hitTest-based dispatch
- Fix `useMouse` hook press detection (button 0 = left click, not "no button")
- Export `parseSgrMouse` parser for reuse and testing

## Test plan
- [x] Unit tests for SGR mouse sequence parser (7 tests: press, release, move, scroll up/down, invalid input, large coordinates)
- [x] Unit tests for `handleMouseFromStdin` dispatch (5 tests: onClick, onMouseUp, onMouseMove, event listener notification, hitTest dispatch with bubbling)
- [x] All 381 existing tests pass
- [x] 0 lint errors

Closes #100

🤖 Generated with [Claude Code](https://claude.com/claude-code)