### PR TITLE
feat: inline colored spans for syntax highlighting (#102)

### DIFF
--- a/packages/core-rust/src/ffi_bridge.rs
+++ b/packages/core-rust/src/ffi_bridge.rs
@@ -25,6 +25,7 @@ const OP_APPEND_CHILD: u8 = 3;
 const OP_INSERT_BEFORE: u8 = 4;
 const OP_SET_STYLE: u8 = 5;
 const OP_SET_TEXT: u8 = 6;
+const OP_SET_TEXT_SPANS: u8 = 7;
 
 // ---------------------------------------------------------------------------
 // Event types — must stay in sync with TS `EventDecoder`
@@ -66,6 +67,17 @@ struct NodeVisualStyle {
 }
 
 // ---------------------------------------------------------------------------
+// Text span — per-character color override within text content
+// ---------------------------------------------------------------------------
+
+#[derive(Clone, Debug)]
+struct TextColorSpan {
+    start: u16,
+    end: u16,
+    fg: Color,
+}
+
+// ---------------------------------------------------------------------------
 // Global engine state
 // ---------------------------------------------------------------------------
 
@@ -75,6 +87,8 @@ struct EngineState {
     node_map: HashMap<u32, LayoutNodeId>,
     /// Text content per node (`node_id` to string).
     text_content: HashMap<u32, String>,
+    /// Per-node text color spans for inline styling.
+    text_spans: HashMap<u32, Vec<TextColorSpan>>,
     /// Pending events encoded as binary.
     event_buffer: Vec<u8>,
     /// Root node id (first node created, or explicitly set).
@@ -107,6 +121,7 @@ impl EngineState {
             layout: LayoutTree::new(),
             node_map: HashMap::new(),
             text_content: HashMap::new(),
+            text_spans: HashMap::new(),
             event_buffer: Vec::new(),
             root_node: None,
             dirty: false,
@@ -646,6 +661,7 @@ fn process_mutation(reader: &mut MutationReader<'_>, state: &mut EngineState) ->
         OP_INSERT_BEFORE => mut_insert_before(reader, state),
         OP_SET_STYLE => mut_set_style(reader, state),
         OP_SET_TEXT => mut_set_text(reader, state),
+        OP_SET_TEXT_SPANS => mut_set_text_spans(reader, state),
         _ => false,
     };
     if ok {
@@ -688,6 +704,7 @@ fn mut_remove_node(reader: &mut MutationReader<'_>, state: &mut EngineState) -> 
         let _ = state.layout.remove(layout_id);
     }
     state.text_content.remove(&node_id);
+    state.text_spans.remove(&node_id);
     state.visual_styles.remove(&node_id);
     true
 }
@@ -759,6 +776,44 @@ fn mut_set_text(reader: &mut MutationReader<'_>, state: &mut EngineState) -> boo
     };
     if let Ok(text) = std::str::from_utf8(text_bytes) {
         state.text_content.insert(node_id, text.to_owned());
+    }
+    true
+}
+
+fn mut_set_text_spans(reader: &mut MutationReader<'_>, state: &mut EngineState) -> bool {
+    let Some(node_id) = reader.read_u32() else {
+        return false;
+    };
+    let Some(span_count) = reader.read_u16() else {
+        return false;
+    };
+    let mut spans = Vec::with_capacity(span_count as usize);
+    for _ in 0..span_count {
+        let Some(start) = reader.read_u16() else {
+            return false;
+        };
+        let Some(end) = reader.read_u16() else {
+            return false;
+        };
+        let Some(r) = reader.read_u8() else {
+            return false;
+        };
+        let Some(g) = reader.read_u8() else {
+            return false;
+        };
+        let Some(b) = reader.read_u8() else {
+            return false;
+        };
+        spans.push(TextColorSpan {
+            start,
+            end,
+            fg: Color::Rgb(r, g, b),
+        });
+    }
+    if spans.is_empty() {
+        state.text_spans.remove(&node_id);
+    } else {
+        state.text_spans.insert(node_id, spans);
     }
     true
 }
@@ -866,7 +921,7 @@ fn paint_node(
         }
     }
 
-    // Paint text content — use resolved colours and text attributes.
+    // Paint text content — use resolved colours, text attributes, and per-span overrides.
     // Respect text_overflow: Clip stops at boundary, Ellipsis places an ellipsis at the end.
     let text_overflow = vs.map_or(TextOverflow::Clip, |v| v.text_overflow);
     if let Some(text) = state.text_content.get(&node_id) {
@@ -874,6 +929,7 @@ fn paint_node(
             let char_count = text.chars().count();
             let needs_ellipsis = text_overflow == TextOverflow::Ellipsis && char_count > w;
             let paint_limit = if needs_ellipsis { w - 1 } else { w };
+            let spans = state.text_spans.get(&node_id);
             for (i, ch) in text.chars().enumerate() {
                 if i >= paint_limit {
                     break;
@@ -887,9 +943,14 @@ fn paint_node(
                         cell.ch = ch;
                         cell.style.bold = resolved_bold;
                         cell.style.italic = resolved_italic;
-                        if let Some(fg) = resolved_fg {
-                            cell.style.fg = Some(fg);
-                        }
+                        let span_fg = spans.and_then(|ss| {
+                            let idx = i as u16;
+                            ss.iter()
+                                .rev()
+                                .find(|s| idx >= s.start && idx < s.end)
+                                .map(|s| s.fg)
+                        });
+                        cell.style.fg = span_fg.or(resolved_fg);
                         if let Some(bg) = resolved_bg {
                             cell.style.bg = Some(bg);
                         }

--- a/packages/core/src/colored-spans.test.ts
+++ b/packages/core/src/colored-spans.test.ts
@@ -1,0 +1,169 @@
+/**
+ * E2E tests for inline colored spans (issue #102).
+ *
+ * Verifies that text color spans are correctly painted per-character.
+ */
+
+import { describe, test, expect, afterEach } from "bun:test";
+import { TestBridge } from "./test-harness/test-bridge.js";
+import { VirtualScreen } from "./test-harness/virtual-screen.js";
+
+let bridge: TestBridge;
+
+const canRun = new TestBridge().nativeAvailable;
+
+describe.skipIf(!canRun)("colored spans", () => {
+  afterEach(() => {
+    bridge?.shutdownTestMode();
+  });
+
+  test("two colored spans render side by side on the same row", () => {
+    bridge = new TestBridge();
+    bridge.initTestMode(80, 24);
+
+    const enc = bridge.getEncoder();
+
+    // Root container
+    enc.createNode(1, {
+      width: 80,
+      height: 24,
+    });
+
+    // Text node with 2-char content
+    enc.createNode(2, {
+      width: 2,
+      height: 1,
+    });
+    enc.setText(2, "AB");
+    enc.setTextSpans(2, [
+      { start: 0, end: 1, r: 255, g: 0, b: 0 },   // A = red
+      { start: 1, end: 2, r: 0, g: 0, b: 255 },    // B = blue
+    ]);
+    enc.appendChild(1, 2);
+
+    bridge.flushMutations();
+    bridge.renderFrame();
+
+    const output = bridge.getRenderedOutput();
+    const screen = new VirtualScreen(80, 24);
+    screen.apply(output);
+
+    expect(screen.textAt(0, 0)).toBe("A");
+    expect(screen.fgAt(0, 0)).toBe("#ff0000");
+    expect(screen.textAt(0, 1)).toBe("B");
+    expect(screen.fgAt(0, 1)).toBe("#0000ff");
+  });
+
+  test("three spans with different colors all visible", () => {
+    bridge = new TestBridge();
+    bridge.initTestMode(80, 24);
+
+    const enc = bridge.getEncoder();
+
+    enc.createNode(1, {
+      width: 80,
+      height: 24,
+    });
+
+    enc.createNode(2, {
+      width: 9,
+      height: 1,
+    });
+    enc.setText(2, "RedGrnBlu");
+    enc.setTextSpans(2, [
+      { start: 0, end: 3, r: 255, g: 0, b: 0 },
+      { start: 3, end: 6, r: 0, g: 255, b: 0 },
+      { start: 6, end: 9, r: 0, g: 0, b: 255 },
+    ]);
+    enc.appendChild(1, 2);
+
+    bridge.flushMutations();
+    bridge.renderFrame();
+
+    const output = bridge.getRenderedOutput();
+    const screen = new VirtualScreen(80, 24);
+    screen.apply(output);
+
+    expect(screen.fgAt(0, 0)).toBe("#ff0000");
+    expect(screen.fgAt(0, 3)).toBe("#00ff00");
+    expect(screen.fgAt(0, 6)).toBe("#0000ff");
+  });
+
+  test("spans can be updated after initial render", () => {
+    bridge = new TestBridge();
+    bridge.initTestMode(80, 24);
+
+    const enc = bridge.getEncoder();
+
+    enc.createNode(1, {
+      width: 80,
+      height: 24,
+    });
+
+    enc.createNode(2, {
+      width: 2,
+      height: 1,
+    });
+    enc.setText(2, "XY");
+    enc.setTextSpans(2, [
+      { start: 0, end: 1, r: 255, g: 0, b: 0 },
+      { start: 1, end: 2, r: 0, g: 255, b: 0 },
+    ]);
+    enc.appendChild(1, 2);
+
+    bridge.flushMutations();
+    bridge.renderFrame();
+
+    let output = bridge.getRenderedOutput();
+    let screen = new VirtualScreen(80, 24);
+    screen.apply(output);
+
+    expect(screen.fgAt(0, 0)).toBe("#ff0000");
+    expect(screen.fgAt(0, 1)).toBe("#00ff00");
+
+    // Update: swap colors
+    enc.setTextSpans(2, [
+      { start: 0, end: 1, r: 0, g: 255, b: 0 },
+      { start: 1, end: 2, r: 255, g: 0, b: 0 },
+    ]);
+
+    bridge.flushMutations();
+    bridge.renderFrame();
+
+    output = bridge.getRenderedOutput();
+    screen = new VirtualScreen(80, 24);
+    screen.apply(output);
+
+    expect(screen.fgAt(0, 0)).toBe("#00ff00");
+    expect(screen.fgAt(0, 1)).toBe("#ff0000");
+  });
+
+  test("text without spans uses node fg color", () => {
+    bridge = new TestBridge();
+    bridge.initTestMode(80, 24);
+
+    const enc = bridge.getEncoder();
+
+    enc.createNode(1, {
+      width: 80,
+      height: 24,
+    });
+
+    enc.createNode(2, {
+      width: 5,
+      height: 1,
+      color: "#808080",
+    });
+    enc.setText(2, "Hello");
+    enc.appendChild(1, 2);
+
+    bridge.flushMutations();
+    bridge.renderFrame();
+
+    const output = bridge.getRenderedOutput();
+    const screen = new VirtualScreen(80, 24);
+    screen.apply(output);
+
+    expect(screen.fgAt(0, 0)).toBe("#808080");
+  });
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -9,6 +9,7 @@ import { lib } from "./ffi.js";
 export { nativeAvailable } from "./ffi.js";
 
 export { MutationEncoder } from "./mutation-encoder.js";
+export type { EncodedTextSpan } from "./mutation-encoder.js";
 export { EventDecoder } from "./event-decoder.js";
 export type {
   KittyEvent,

--- a/packages/core/src/mutation-encoder.ts
+++ b/packages/core/src/mutation-encoder.ts
@@ -15,6 +15,18 @@ const OP_APPEND_CHILD = 3;
 const OP_INSERT_BEFORE = 4;
 const OP_SET_STYLE = 5;
 const OP_SET_TEXT = 6;
+const OP_SET_TEXT_SPANS = 7;
+
+/** A single color span for setTextSpans. */
+export interface EncodedTextSpan {
+  start: number;
+  end: number;
+  r: number;
+  g: number;
+  b: number;
+}
+
+const BYTES_PER_SPAN = 7;
 
 const INITIAL_CAPACITY = 4096;
 const PERCENT_DIVISOR = 100;
@@ -237,6 +249,27 @@ export class MutationEncoder {
     this.writeU32(nodeId);
     this.writeU16(textBytes.byteLength);
     this.writeBytes(textBytes);
+  }
+
+  /**
+   * Send per-span fg color data for a text node.
+   *
+   * Binary format:
+   *   [OP_SET_TEXT_SPANS:u8][node_id:u32][span_count:u16]
+   *   per span: [start:u16][end:u16][r:u8][g:u8][b:u8]
+   */
+  setTextSpans(nodeId: number, spans: readonly EncodedTextSpan[]): void {
+    this.ensureCapacity(1 + 4 + 2 + spans.length * BYTES_PER_SPAN);
+    this.writeU8(OP_SET_TEXT_SPANS);
+    this.writeU32(nodeId);
+    this.writeU16(spans.length);
+    for (const span of spans) {
+      this.writeU16(span.start);
+      this.writeU16(span.end);
+      this.writeU8(span.r);
+      this.writeU8(span.g);
+      this.writeU8(span.b);
+    }
   }
 
   // -----------------------------------------------------------------------

--- a/packages/core/src/renderable-tree.ts
+++ b/packages/core/src/renderable-tree.ts
@@ -238,6 +238,9 @@ export class RenderableTree {
         if (node.renderable.text !== undefined) {
           this.encoder.setText(node.renderable.nodeId, node.renderable.text);
         }
+        if (node.renderable.colorSpans.length > 0) {
+          this.encoder.setTextSpans(node.renderable.nodeId, node.renderable.colorSpans);
+        }
         node.renderable.clearDirty();
       }
     }

--- a/packages/core/src/renderable.ts
+++ b/packages/core/src/renderable.ts
@@ -5,6 +5,7 @@
  * The Renderable manages its own node ID, style, text content, and lifecycle.
  */
 
+import type { EncodedTextSpan } from "./mutation-encoder.js";
 import { type CSSStyle, normalizeStyle } from "./style.js";
 import type { ComputedLayout, NodeStyle, TextStyle } from "./types.js";
 
@@ -92,6 +93,22 @@ export abstract class Renderable {
 
   setText(text: string | undefined): void {
     this._text = text;
+    this._dirty = true;
+  }
+
+  // -----------------------------------------------------------------------
+  // Color spans (for inline colored text)
+  // -----------------------------------------------------------------------
+
+  /** Encoded color spans for per-character fg color overrides. */
+  private _colorSpans: EncodedTextSpan[] = [];
+
+  get colorSpans(): readonly EncodedTextSpan[] {
+    return this._colorSpans;
+  }
+
+  setColorSpans(spans: EncodedTextSpan[]): void {
+    this._colorSpans = spans;
     this._dirty = true;
   }
 

--- a/packages/react/src/host-config.ts
+++ b/packages/react/src/host-config.ts
@@ -4,8 +4,8 @@
  * Maps React's tree operations to mutations on a RenderableTree.
  */
 
+import type { EncodedTextSpan, RenderableTree, RgbColor } from "@kittyui/core";
 import { type BoxRenderable, type ImageRenderable, type KittyProps, type TextRenderable, createRenderableForType } from "./renderables.js";
-import type { RenderableTree } from "@kittyui/core";
 
 // ---------------------------------------------------------------------------
 // Active tree reference — set by createRoot so host-config callbacks can
@@ -68,6 +68,62 @@ const applyCommitUpdate = ({ instance, nextProps }: CommitUpdateArgs): void => {
 };
 
 // ---------------------------------------------------------------------------
+// Inline span tracking — maps parent Text node IDs to their inline children
+// so we can rebuild concatenated text + color spans.
+// ---------------------------------------------------------------------------
+
+interface InlineChild {
+  instance: TextRenderable;
+  text: string;
+}
+
+const inlineChildren = new Map<number, InlineChild[]>();
+
+/** Track instances created via createTextInstance (raw strings, not <text> JSX elements). */
+const rawTextInstances = new WeakSet<TextRenderable>();
+
+const isTextRenderable = (inst: BoxRenderable | ImageRenderable | TextRenderable): inst is TextRenderable =>
+  inst.type === "text";
+
+const extractRgb = (color: RgbColor): { r: number; g: number; b: number } => ({
+  b: color.b,
+  g: color.g,
+  r: color.r,
+});
+
+const rebuildInlineSpans = (parent: TextRenderable): void => {
+  const children = inlineChildren.get(parent.nodeId);
+  if (!children || children.length === 0) {
+    parent.setText(undefined);
+    parent.setColorSpans([]);
+    parent.setNodeStyle({});
+    return;
+  }
+
+  let concatenated = "";
+  const spans: EncodedTextSpan[] = [];
+
+  for (const child of children) {
+    const start = concatenated.length;
+    concatenated += child.text;
+    const end = concatenated.length;
+
+    const fg = child.instance.textStyle.fg;
+    if (fg && fg.type === "rgb") {
+      const { r, g, b } = extractRgb(fg);
+      spans.push({ b, end, g, r, start });
+    }
+  }
+
+  parent.setText(concatenated);
+  parent.setColorSpans(spans);
+  parent.setNodeStyle({
+    height: { type: "cells", value: 1 },
+    width: { type: "cells", value: concatenated.length },
+  });
+};
+
+// ---------------------------------------------------------------------------
 // Host config
 // ---------------------------------------------------------------------------
 
@@ -75,6 +131,15 @@ export const hostConfig = {
   afterActiveInstanceBlur(): void {},
 
   appendChild(parentInstance: Instance, child: Instance | TextInstance): void {
+    if (isTextRenderable(parentInstance) && isTextRenderable(child) && !rawTextInstances.has(child)) {
+      const childText = child.text ?? "";
+      if (!inlineChildren.has(parentInstance.nodeId)) {
+        inlineChildren.set(parentInstance.nodeId, []);
+      }
+      inlineChildren.get(parentInstance.nodeId)!.push({ instance: child, text: childText });
+      rebuildInlineSpans(parentInstance);
+      return;
+    }
     activeTree?.appendChild(parentInstance.nodeId, child);
   },
 
@@ -83,6 +148,15 @@ export const hostConfig = {
   },
 
   appendInitialChild(parentInstance: Instance, child: Instance | TextInstance): void {
+    if (isTextRenderable(parentInstance) && isTextRenderable(child) && !rawTextInstances.has(child)) {
+      const childText = child.text ?? "";
+      if (!inlineChildren.has(parentInstance.nodeId)) {
+        inlineChildren.set(parentInstance.nodeId, []);
+      }
+      inlineChildren.get(parentInstance.nodeId)!.push({ instance: child, text: childText });
+      rebuildInlineSpans(parentInstance);
+      return;
+    }
     activeTree?.appendChild(parentInstance.nodeId, child);
   },
 
@@ -99,7 +173,21 @@ export const hostConfig = {
 
   commitTextUpdate(textInstance: TextInstance, _oldText: string, newText: string): void {
     textInstance.setText(newText);
-    // Auto-size text node to its content width.
+
+    // Check if this text instance is an inline child of a Text parent.
+    for (const [parentId, children] of inlineChildren) {
+      const entry = children.find((c) => c.instance.nodeId === textInstance.nodeId);
+      if (entry) {
+        entry.text = newText;
+        const parentRenderable = activeTree?.get(parentId) as TextRenderable | undefined;
+        if (parentRenderable) {
+          rebuildInlineSpans(parentRenderable);
+        }
+        return;
+      }
+    }
+
+    // Not an inline child — normal text node, auto-size.
     textInstance.setNodeStyle({
       height: { type: "cells", value: 1 },
       width: { type: "cells", value: newText.length },
@@ -121,11 +209,11 @@ export const hostConfig = {
   createTextInstance(text: string, _rootContainer: Container): TextInstance {
     const instance = createRenderableForType("text") as TextRenderable;
     instance.setText(text);
-    // Auto-size text node to its content width.
     instance.setNodeStyle({
       height: { type: "cells", value: 1 },
       width: { type: "cells", value: text.length },
     });
+    rawTextInstances.add(instance);
     activeTree?.addOrphan(instance);
     return instance;
   },


### PR DESCRIPTION
## Summary
- Adds per-character foreground color spans to text nodes via a new `OP_SET_TEXT_SPANS` binary op (code 7)
- React host-config intercepts `<Text>` children nested inside `<Text>` parents, concatenating their content and tracking color span metadata instead of creating separate layout nodes
- Rust `paint_node` applies span-level fg colors during text rendering, falling back to the node's fg color for unspanned characters

## Changes
- `packages/core/src/mutation-encoder.ts` — new `setTextSpans()` method and `EncodedTextSpan` interface
- `packages/core/src/renderable.ts` — `colorSpans` storage on Renderable base class
- `packages/core/src/renderable-tree.ts` — flush color spans alongside dirty styles
- `packages/react/src/host-config.ts` — inline span collection with `rawTextInstances` guard to distinguish raw strings from `<text>` JSX elements
- `packages/core-rust/src/ffi_bridge.rs` — `TextColorSpan` struct, `mut_set_text_spans` handler, per-char span lookup in `paint_node`
- `packages/core/src/colored-spans.test.ts` — 4 E2E tests

## Test plan
- [x] 4 new E2E tests for colored spans (two spans, three spans, span update, fallback to node fg)
- [x] All 721 existing tests pass
- [x] `bun run typecheck` passes
- [x] `bun run lint:ts` — 0 errors

Closes #102

🤖 Generated with [Claude Code](https://claude.com/claude-code)