### PR TITLE
Font subsystem with cosmic-text for glyph rasterization

### DIFF
--- a/packages/core-rust/Cargo.lock
+++ b/packages/core-rust/Cargo.lock
@@ -37,6 +37,20 @@ name = "bytemuck"
 version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "byteorder-lite"
@@ -57,6 +71,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
 
 [[package]]
+name = "cosmic-text"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59fd57d82eb4bfe7ffa9b1cec0c05e2fd378155b47f255a67983cb4afe0e80c2"
+dependencies = [
+ "bitflags",
+ "fontdb",
+ "log",
+ "rangemap",
+ "rayon",
+ "rustc-hash",
+ "rustybuzz",
+ "self_cell",
+ "swash",
+ "sys-locale",
+ "ttf-parser 0.21.1",
+ "unicode-bidi",
+ "unicode-linebreak",
+ "unicode-script",
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -64,6 +101,37 @@ checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "errno"
@@ -92,6 +160,38 @@ checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+]
+
+[[package]]
+name = "font-types"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3971f9a5ca983419cdc386941ba3b9e1feba01a0ab888adf78739feb2798492"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
+name = "fontconfig-parser"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbc773e24e02d4ddd8395fd30dc147524273a83e54e0f312d986ea30de5f5646"
+dependencies = [
+ "roxmltree",
+]
+
+[[package]]
+name = "fontdb"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0299020c3ef3f60f526a4f64ab4a3d4ce116b1acbf24cdd22da0068e5d81dc3"
+dependencies = [
+ "fontconfig-parser",
+ "log",
+ "memmap2",
+ "slotmap",
+ "tinyvec",
+ "ttf-parser 0.20.0",
 ]
 
 [[package]]
@@ -184,6 +284,7 @@ name = "kittyui-core"
 version = "0.1.0"
 dependencies = [
  "base64",
+ "cosmic-text",
  "flate2",
  "image",
  "libc",
@@ -199,6 +300,12 @@ name = "libc"
 version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+
+[[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "lock_api"
@@ -220,6 +327,15 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "memmap2"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "miniz_oxide"
@@ -329,12 +445,77 @@ dependencies = [
 ]
 
 [[package]]
+name = "rangemap"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "973443cf09a9c8656b574a866ab68dfa19f0867d0340648c7d2f6a71b8a8ea68"
+
+[[package]]
+name = "rayon"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "read-fonts"
+version = "0.22.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69aacb76b5c29acfb7f90155d39759a29496aebb49395830e928a9703d2eec2f"
+dependencies = [
+ "bytemuck",
+ "font-types",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "roxmltree"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c20b6793b5c2fa6553b250154b78d6d0db37e72700ae35fad9387a46f487c97"
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustybuzz"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfb9cf8877777222e4a3bc7eb247e398b56baba500c38c1c46842431adc8b55c"
+dependencies = [
+ "bitflags",
+ "bytemuck",
+ "libm",
+ "smallvec",
+ "ttf-parser 0.21.1",
+ "unicode-bidi-mirroring",
+ "unicode-ccc",
+ "unicode-properties",
+ "unicode-script",
 ]
 
 [[package]]
@@ -357,6 +538,12 @@ name = "sdd"
 version = "3.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
+
+[[package]]
+name = "self_cell"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b12e76d157a900eb52e81bc6e9f3069344290341720e9178cde2407113ac8d89"
 
 [[package]]
 name = "serde"
@@ -454,6 +641,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
 
 [[package]]
+name = "skrifa"
+version = "0.22.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1c44ad1f6c5bdd4eefed8326711b7dbda9ea45dfd36068c427d332aa382cbe"
+dependencies = [
+ "bytemuck",
+ "read-fonts",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -475,6 +672,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
+name = "swash"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbd59f3f359ddd2c95af4758c18270eddd9c730dde98598023cdabff472c2ca2"
+dependencies = [
+ "skrifa",
+ "yazi",
+ "zeno",
+]
+
+[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -483,6 +691,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "sys-locale"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eab9a99a024a169fe8a903cf9d4a3b3601109bcc13bd9e3c6fff259138626c4"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -498,10 +715,79 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "ttf-parser"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17f77d76d837a7830fe1d4f12b7b4ba4192c1888001c7164257e4bc6d21d96b4"
+
+[[package]]
+name = "ttf-parser"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c591d83f69777866b9126b24c6dd9a18351f177e49d625920d19f989fd31cf8"
+
+[[package]]
+name = "unicode-bidi"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
+
+[[package]]
+name = "unicode-bidi-mirroring"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23cb788ffebc92c5948d0e997106233eeb1d8b9512f93f41651f52b6c5f5af86"
+
+[[package]]
+name = "unicode-ccc"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1df77b101bcc4ea3d78dafc5ad7e4f58ceffe0b2b16bf446aeb50b6cb4157656"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-linebreak"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
+
+[[package]]
+name = "unicode-properties"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
+
+[[package]]
+name = "unicode-script"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "383ad40bb927465ec0ce7720e033cb4ca06912855fc35db31b5755d0de75b1ee"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
 
 [[package]]
 name = "version_check"
@@ -529,6 +815,18 @@ checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "yazi"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c94451ac9513335b5e23d7a8a2b61a7102398b8cca5160829d313e84c9d98be1"
+
+[[package]]
+name = "zeno"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd15f8e0dbb966fd9245e7498c7e9e5055d9e5c8b676b95bd67091cd11a1e697"
 
 [[package]]
 name = "zmij"

--- a/packages/core-rust/Cargo.toml
+++ b/packages/core-rust/Cargo.toml
@@ -10,6 +10,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 base64 = "0.22"
+cosmic-text = "0.12"
 flate2 = "1.0"
 image = { version = "0.25", default-features = false, features = ["png", "jpeg", "gif", "webp"] }
 libc = "0.2"

--- a/packages/core-rust/src/font_system.rs
+++ b/packages/core-rust/src/font_system.rs
@@ -1,0 +1,199 @@
+//! Font subsystem powered by `cosmic-text` for text measurement and glyph
+//! rasterization.
+//!
+//! [`FontSystem`] wraps a `cosmic_text::FontSystem` (which discovers system
+//! fonts automatically) and a `SwashCache` for glyph rasterization.  It
+//! exposes two main operations:
+//!
+//! - **measure** — compute the pixel dimensions of a shaped text run.
+//! - **rasterize** — produce positioned coverage bitmaps for compositing
+//!   onto a [`crate::pixel_canvas::PixelCanvas`].
+
+// Glyph positioning math uses many short variable names and numeric casts.
+#![allow(
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss,
+    clippy::cast_precision_loss,
+    clippy::cast_lossless
+)]
+
+use cosmic_text::{
+    Attrs, Buffer, Family, FontSystem as CosmicFontSystem, Metrics, Shaping, SwashCache, Weight,
+};
+
+/// Manages font loading, text measurement, and glyph rasterization.
+pub struct FontSystem {
+    font_system: CosmicFontSystem,
+    swash_cache: SwashCache,
+}
+
+impl FontSystem {
+    /// Create a new font system with system fonts loaded.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            font_system: CosmicFontSystem::new(),
+            swash_cache: SwashCache::new(),
+        }
+    }
+
+    /// Measure the pixel dimensions of a text string.
+    ///
+    /// Returns `(width, height)` in pixels.  For an empty string the width
+    /// is zero and the height equals the font size.
+    pub fn measure_text(&mut self, text: &str, font_size: f32, bold: bool) -> (f32, f32) {
+        let metrics = Metrics::new(font_size, font_size * 1.2);
+        let mut buffer = Buffer::new(&mut self.font_system, metrics);
+
+        let weight = if bold { Weight::BOLD } else { Weight::NORMAL };
+        let attrs = Attrs::new().family(Family::Monospace).weight(weight);
+
+        buffer.set_text(&mut self.font_system, text, attrs, Shaping::Advanced);
+        buffer.shape_until_scroll(&mut self.font_system, false);
+
+        let width = buffer
+            .layout_runs()
+            .flat_map(|run| run.glyphs.iter())
+            .map(|g| g.x + g.w)
+            .fold(0.0f32, f32::max);
+        let height = buffer.layout_runs().map(|run| run.line_height).sum::<f32>();
+
+        (width.max(0.0), height.max(font_size))
+    }
+
+    /// Rasterize text and return positioned glyphs with their coverage
+    /// bitmaps.
+    ///
+    /// Each [`RasterizedGlyph`] contains the bitmap position, dimensions,
+    /// and an alpha-coverage buffer suitable for compositing onto a
+    /// [`crate::pixel_canvas::PixelCanvas`].
+    pub fn rasterize_text(
+        &mut self,
+        text: &str,
+        font_size: f32,
+        bold: bool,
+        italic: bool,
+    ) -> Vec<RasterizedGlyph> {
+        let metrics = Metrics::new(font_size, font_size * 1.2);
+        let mut buffer = Buffer::new(&mut self.font_system, metrics);
+
+        let weight = if bold { Weight::BOLD } else { Weight::NORMAL };
+        let style = if italic {
+            cosmic_text::Style::Italic
+        } else {
+            cosmic_text::Style::Normal
+        };
+        let attrs = Attrs::new()
+            .family(Family::Monospace)
+            .weight(weight)
+            .style(style);
+
+        buffer.set_text(&mut self.font_system, text, attrs, Shaping::Advanced);
+        buffer.shape_until_scroll(&mut self.font_system, false);
+
+        let mut glyphs = Vec::new();
+
+        for run in buffer.layout_runs() {
+            for glyph in run.glyphs {
+                let physical = glyph.physical((0., 0.), 1.0);
+
+                if let Some(image) = self
+                    .swash_cache
+                    .get_image(&mut self.font_system, physical.cache_key)
+                {
+                    glyphs.push(RasterizedGlyph {
+                        x: physical.x as f32 + image.placement.left as f32,
+                        y: run.line_y + physical.y as f32 - image.placement.top as f32,
+                        width: image.placement.width,
+                        height: image.placement.height,
+                        data: image.data.clone(),
+                    });
+                }
+            }
+        }
+
+        glyphs
+    }
+
+    /// Get a mutable reference to the underlying `cosmic_text::FontSystem`.
+    pub fn inner_mut(&mut self) -> &mut CosmicFontSystem {
+        &mut self.font_system
+    }
+}
+
+impl Default for FontSystem {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// A rasterized glyph with position and coverage bitmap.
+#[derive(Debug, Clone)]
+pub struct RasterizedGlyph {
+    /// X position in pixels (relative to text origin).
+    pub x: f32,
+    /// Y position in pixels (relative to text origin).
+    pub y: f32,
+    /// Bitmap width in pixels.
+    pub width: u32,
+    /// Bitmap height in pixels.
+    pub height: u32,
+    /// Coverage bitmap (grayscale, 1 byte per pixel).
+    /// Length = `width * height`.
+    pub data: Vec<u8>,
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_creates_font_system_without_panicking() {
+        let _fs = FontSystem::new();
+    }
+
+    #[test]
+    fn measure_text_returns_nonzero_dimensions() {
+        let mut fs = FontSystem::new();
+        let (w, h) = fs.measure_text("Hello", 16.0, false);
+        assert!(w > 0.0, "width should be > 0, got {w}");
+        assert!(h > 0.0, "height should be > 0, got {h}");
+    }
+
+    #[test]
+    fn rasterize_text_produces_glyphs() {
+        let mut fs = FontSystem::new();
+        let glyphs = fs.rasterize_text("A", 16.0, false, false);
+        assert!(!glyphs.is_empty(), "should produce at least 1 glyph");
+        let g = &glyphs[0];
+        assert!(!g.data.is_empty(), "glyph data should not be empty");
+    }
+
+    #[test]
+    fn measure_empty_string_returns_zero_width() {
+        let mut fs = FontSystem::new();
+        let (w, h) = fs.measure_text("", 16.0, false);
+        assert!(
+            w.abs() < f32::EPSILON,
+            "empty string width should be 0, got {w}"
+        );
+        assert!(h >= 16.0, "height should be at least font_size, got {h}");
+    }
+
+    #[test]
+    fn bold_monospace_has_similar_width() {
+        let mut fs = FontSystem::new();
+        let (w_normal, _) = fs.measure_text("Hello", 16.0, false);
+        let (w_bold, _) = fs.measure_text("Hello", 16.0, true);
+        // Monospace fonts should have identical or very similar widths
+        let diff = (w_normal - w_bold).abs();
+        assert!(
+            diff < w_normal * 0.15,
+            "bold width ({w_bold}) should be similar to normal ({w_normal}), diff={diff}"
+        );
+    }
+}

--- a/packages/core-rust/src/lib.rs
+++ b/packages/core-rust/src/lib.rs
@@ -10,6 +10,7 @@ pub mod cell;
 pub mod cleanup;
 pub mod ffi_bridge;
 pub mod focus;
+pub mod font_system;
 pub mod hit_test;
 pub mod image;
 pub mod image_placement;


### PR DESCRIPTION
## Summary
- Add `cosmic-text` v0.12 dependency for text shaping, layout, and rasterization
- Create `font_system` module with `FontSystem` struct wrapping cosmic-text's `FontSystem` and `SwashCache`
- Expose `measure_text()` for pixel-dimension measurement and `rasterize_text()` for producing positioned coverage bitmaps ready for compositing onto `PixelCanvas`
- Uses system fonts automatically (no embedded font files), monospace family by default, with bold/italic support

## Test plan
- [x] `FontSystem::new()` creates without panicking
- [x] `measure_text("Hello", 16.0, false)` returns non-zero dimensions
- [x] `rasterize_text("A", 16.0, false, false)` produces at least 1 glyph with non-empty data
- [x] Empty string returns zero width with height >= font_size
- [x] Bold monospace has similar width to normal (within 15%)
- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] All 34 existing tests still pass

Closes #127

🤖 Generated with [Claude Code](https://claude.com/claude-code)