### PR TITLE
fix: font_system.rs emoji support and measure_text italic parity

### DIFF
--- a/packages/core-rust/src/font_system.rs
+++ b/packages/core-rust/src/font_system.rs
@@ -18,7 +18,8 @@
 )]
 
 use cosmic_text::{
-    Attrs, Buffer, Family, FontSystem as CosmicFontSystem, Metrics, Shaping, SwashCache, Weight,
+    Attrs, Buffer, Family, FontSystem as CosmicFontSystem, Metrics, Shaping, SwashCache,
+    SwashContent, Weight,
 };
 
 /// Manages font loading, text measurement, and glyph rasterization.
@@ -41,12 +42,26 @@ impl FontSystem {
     ///
     /// Returns `(width, height)` in pixels.  For an empty string the width
     /// is zero and the height equals the font size.
-    pub fn measure_text(&mut self, text: &str, font_size: f32, bold: bool) -> (f32, f32) {
+    pub fn measure_text(
+        &mut self,
+        text: &str,
+        font_size: f32,
+        bold: bool,
+        italic: bool,
+    ) -> (f32, f32) {
         let metrics = Metrics::new(font_size, font_size * 1.2);
         let mut buffer = Buffer::new(&mut self.font_system, metrics);
 
         let weight = if bold { Weight::BOLD } else { Weight::NORMAL };
-        let attrs = Attrs::new().family(Family::Monospace).weight(weight);
+        let style = if italic {
+            cosmic_text::Style::Italic
+        } else {
+            cosmic_text::Style::Normal
+        };
+        let attrs = Attrs::new()
+            .family(Family::Monospace)
+            .weight(weight)
+            .style(style);
 
         buffer.set_text(&mut self.font_system, text, attrs, Shaping::Advanced);
         buffer.shape_until_scroll(&mut self.font_system, false);
@@ -101,11 +116,17 @@ impl FontSystem {
                     .swash_cache
                     .get_image(&mut self.font_system, physical.cache_key)
                 {
+                    let content = match image.content {
+                        SwashContent::Mask => GlyphContent::Mask,
+                        SwashContent::Color => GlyphContent::Color,
+                        SwashContent::SubpixelMask => continue,
+                    };
                     glyphs.push(RasterizedGlyph {
                         x: physical.x as f32 + image.placement.left as f32,
                         y: run.line_y + physical.y as f32 - image.placement.top as f32,
                         width: image.placement.width,
                         height: image.placement.height,
+                        content,
                         data: image.data.clone(),
                     });
                 }
@@ -127,6 +148,15 @@ impl Default for FontSystem {
     }
 }
 
+/// Describes the content format of a rasterized glyph's bitmap data.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GlyphContent {
+    /// 8-bit alpha mask (1 byte per pixel grayscale coverage) — for normal text.
+    Mask,
+    /// 32-bit RGBA bitmap (4 bytes per pixel) — for color emoji.
+    Color,
+}
+
 /// A rasterized glyph with position and coverage bitmap.
 #[derive(Debug, Clone)]
 pub struct RasterizedGlyph {
@@ -138,8 +168,10 @@ pub struct RasterizedGlyph {
     pub width: u32,
     /// Bitmap height in pixels.
     pub height: u32,
-    /// Coverage bitmap (grayscale, 1 byte per pixel).
-    /// Length = `width * height`.
+    /// The content format of the bitmap data.
+    pub content: GlyphContent,
+    /// Coverage bitmap — either grayscale (1 byte/pixel) for [`GlyphContent::Mask`]
+    /// or RGBA (4 bytes/pixel) for [`GlyphContent::Color`].
     pub data: Vec<u8>,
 }
 
@@ -159,7 +191,7 @@ mod tests {
     #[test]
     fn measure_text_returns_nonzero_dimensions() {
         let mut fs = FontSystem::new();
-        let (w, h) = fs.measure_text("Hello", 16.0, false);
+        let (w, h) = fs.measure_text("Hello", 16.0, false, false);
         assert!(w > 0.0, "width should be > 0, got {w}");
         assert!(h > 0.0, "height should be > 0, got {h}");
     }
@@ -176,7 +208,7 @@ mod tests {
     #[test]
     fn measure_empty_string_returns_zero_width() {
         let mut fs = FontSystem::new();
-        let (w, h) = fs.measure_text("", 16.0, false);
+        let (w, h) = fs.measure_text("", 16.0, false, false);
         assert!(
             w.abs() < f32::EPSILON,
             "empty string width should be 0, got {w}"
@@ -187,8 +219,8 @@ mod tests {
     #[test]
     fn bold_monospace_has_similar_width() {
         let mut fs = FontSystem::new();
-        let (w_normal, _) = fs.measure_text("Hello", 16.0, false);
-        let (w_bold, _) = fs.measure_text("Hello", 16.0, true);
+        let (w_normal, _) = fs.measure_text("Hello", 16.0, false, false);
+        let (w_bold, _) = fs.measure_text("Hello", 16.0, true, false);
         // Monospace fonts should have identical or very similar widths
         let diff = (w_normal - w_bold).abs();
         assert!(


### PR DESCRIPTION
## Summary
Quick fixes for `font_system.rs` bugs found during red team review of #135:

- **Add `GlyphContent` enum** — `RasterizedGlyph` now includes a `content: GlyphContent` field that distinguishes `Mask` (1 byte/pixel grayscale) from `Color` (4 bytes/pixel RGBA emoji). `SubpixelMask` glyphs are skipped during rasterization.
- **Add `italic` param to `measure_text`** — `measure_text` now accepts `italic: bool` and applies `cosmic_text::Style::Italic` the same way `rasterize_text` does, ensuring measurement and rasterization use identical font attributes.

## Test plan
- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test` — all 34 tests pass
- [x] `cargo build --release` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)