### PR TITLE
feat: switch pixel renderer to sans-serif font

### DIFF
--- a/packages/core-rust/src/font_system.rs
+++ b/packages/core-rust/src/font_system.rs
@@ -59,7 +59,7 @@ impl FontSystem {
             cosmic_text::Style::Normal
         };
         let attrs = Attrs::new()
-            .family(Family::Monospace)
+            .family(Family::SansSerif)
             .weight(weight)
             .style(style);
 
@@ -99,7 +99,7 @@ impl FontSystem {
             cosmic_text::Style::Normal
         };
         let attrs = Attrs::new()
-            .family(Family::Monospace)
+            .family(Family::SansSerif)
             .weight(weight)
             .style(style);
 
@@ -217,15 +217,15 @@ mod tests {
     }
 
     #[test]
-    fn bold_monospace_has_similar_width() {
+    fn bold_has_similar_width() {
         let mut fs = FontSystem::new();
         let (w_normal, _) = fs.measure_text("Hello", 16.0, false, false);
         let (w_bold, _) = fs.measure_text("Hello", 16.0, true, false);
-        // Monospace fonts should have identical or very similar widths
+        // With sans-serif fonts, bold variants can be noticeably wider
         let diff = (w_normal - w_bold).abs();
         assert!(
-            diff < w_normal * 0.15,
-            "bold width ({w_bold}) should be similar to normal ({w_normal}), diff={diff}"
+            diff < w_normal * 0.5,
+            "bold width ({w_bold}) should be within 50% of normal ({w_normal}), diff={diff}"
         );
     }
 }


### PR DESCRIPTION
## Summary
- Switch `Family::Monospace` to `Family::SansSerif` in both `measure_text` and `rasterize_text` in `font_system.rs`
- Uses the system's default sans-serif font (e.g., Helvetica on macOS, Liberation Sans on Linux)
- Single biggest visual improvement to make the pixel-rendered demo look like a web app instead of a terminal

## Details
No changes needed in `pixel_renderer.rs` -- text still starts at the correct pixel position, and proportional character spacing flows naturally since the pixel renderer draws everything as pixels (cell grid alignment only matters for the cell-based renderer).

The bold-width test tolerance was relaxed from 15% to 50% since sans-serif bold variants are noticeably wider than their normal counterparts (unlike monospace where all glyphs share the same advance width).

## Test plan
- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] All 893 tests pass (892 + the updated bold width test)
- [ ] Visual verification: run the dashboard demo and confirm text renders with proportional sans-serif font

🤖 Generated with [Claude Code](https://claude.com/claude-code)