### PR TITLE
Fix Kitty terminal auto-detection for tmux/screen environments

### DIFF
--- a/packages/core-rust/src/ffi_bridge.rs
+++ b/packages/core-rust/src/ffi_bridge.rs
@@ -278,7 +278,7 @@ struct GradientImage {
 
 impl EngineState {
     fn new() -> Self {
-        Self {
+        let mut this = Self {
             layout: LayoutTree::new(),
             node_map: HashMap::new(),
             text_content: HashMap::new(),
@@ -306,7 +306,19 @@ impl EngineState {
             shadow_images_pending: Vec::new(),
             pixel_renderer: None,
             render_mode: RenderMode::default(),
+        };
+
+        // Allow overriding render mode via KITTYUI_RENDER_MODE env var.
+        // This lets users force pixel or cell mode without passing flags.
+        if let Ok(mode) = std::env::var("KITTYUI_RENDER_MODE") {
+            match mode.as_str() {
+                "pixel" => this.render_mode = RenderMode::Pixel,
+                "cell" => this.render_mode = RenderMode::Cell,
+                _ => {} // "auto" or anything else keeps default
+            }
         }
+
+        this
     }
 
     /// Look up the user-facing u32 id for a layout node id.

--- a/packages/core-rust/src/terminal_caps.rs
+++ b/packages/core-rust/src/terminal_caps.rs
@@ -57,6 +57,11 @@ pub fn detect_from_env() -> TerminalCaps {
         caps.kitty_graphics = true;
     }
 
+    // KITTY_PID is set by Kitty even inside tmux/screen sessions
+    if std::env::var("KITTY_PID").is_ok() {
+        caps.kitty_graphics = true;
+    }
+
     caps
 }
 
@@ -120,6 +125,21 @@ pub fn detect() -> TerminalCaps {
     caps
 }
 
+/// Probe for Kitty graphics support by sending a test transmission.
+/// This is the most reliable detection method.
+/// Returns true if the terminal responds with a Kitty graphics OK response.
+///
+/// Sends: `\x1b_Gi=31,s=1,v=1,a=q,t=d,f=24;AAAA\x1b\\`
+/// Expected response: `\x1b_Gi=31;OK\x1b\\`
+///
+/// NOTE: This requires reading from stdin in raw mode, so it can only be done
+/// during init when we have access to raw mode. For now, rely on env var
+/// detection — this function is a no-op placeholder for future implementation.
+#[must_use]
+pub fn probe_kitty_graphics() -> bool {
+    false
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -175,6 +195,24 @@ mod tests {
             Some(v) => std::env::set_var("KITTY_WINDOW_ID", v),
             None => std::env::remove_var("KITTY_WINDOW_ID"),
         }
+    }
+
+    #[test]
+    fn detect_from_env_respects_kitty_pid() {
+        let prev = std::env::var("KITTY_PID").ok();
+        std::env::set_var("KITTY_PID", "12345");
+        let caps = detect_from_env();
+        assert!(caps.kitty_graphics);
+        match prev {
+            Some(v) => std::env::set_var("KITTY_PID", v),
+            None => std::env::remove_var("KITTY_PID"),
+        }
+    }
+
+    #[test]
+    fn probe_kitty_graphics_returns_false() {
+        // Stub always returns false for now
+        assert!(!probe_kitty_graphics());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Add `KITTY_PID` env var detection in `terminal_caps.rs` — this variable persists inside tmux/screen sessions where `KITTY_WINDOW_ID` may be absent, enabling auto-detection of pixel rendering capability
- Add `probe_kitty_graphics()` stub for future active Kitty graphics protocol query (sends test transmission, reads response)
- Support `KITTYUI_RENDER_MODE` env var override in `ffi_bridge.rs` — users can set `KITTYUI_RENDER_MODE=pixel` or `KITTYUI_RENDER_MODE=cell` to force a render mode without passing `--pixel` flag

## Test plan
- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] All 34 tests pass including new `detect_from_env_respects_kitty_pid` and `probe_kitty_graphics_returns_false` tests
- [ ] Manual: run inside Kitty terminal — pixel rendering should activate automatically
- [ ] Manual: run inside tmux within Kitty — pixel rendering should activate via `KITTY_PID`
- [ ] Manual: `KITTYUI_RENDER_MODE=pixel` forces pixel mode regardless of terminal

🤖 Generated with [Claude Code](https://claude.com/claude-code)